### PR TITLE
[Twitter Adapter] Add unit tests for Result class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
@@ -11,6 +11,11 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bot.Builder.Community.Adapters.Tests/Models/ResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Models/ResultTests.cs
@@ -4,33 +4,32 @@
 using System.Collections.Generic;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Models
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class ResultTests
     {
-        [TestMethod]
+        [Fact]
         public void ConstructorSucceeds()
         {
             var result = new Result<bool>();
 
-            Assert.IsFalse(result.Success);
+            Assert.False(result.Success);
         }
 
-        [TestMethod]
+        [Fact]
         public void ConstructorWithDataSucceeds()
         {
             var result = new Result<bool>(false);
 
-            Assert.IsTrue(result.Success);
-            Assert.IsFalse(result.Data);
+            Assert.True(result.Success);
+            Assert.False(result.Data);
         }
 
-        [TestMethod]
+        [Fact]
         public void ConstructorWithTwitterErrorSucceeds()
         {
             var errors = new List<Error>
@@ -45,8 +44,8 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Models
 
             var result = new Result<bool>(twitterError);
 
-            Assert.IsFalse(result.Success);
-            Assert.AreEqual(twitterError, result.Error);
+            Assert.False(result.Success);
+            Assert.Equal(twitterError, result.Error);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Models/ResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Models/ResultTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Models
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class ResultTests
+    {
+        [TestMethod]
+        public void ConstructorSucceeds()
+        {
+            var result = new Result<bool>();
+
+            Assert.IsFalse(result.Success);
+        }
+
+        [TestMethod]
+        public void ConstructorWithDataSucceeds()
+        {
+            var result = new Result<bool>(false);
+
+            Assert.IsTrue(result.Success);
+            Assert.IsFalse(result.Data);
+        }
+
+        [TestMethod]
+        public void ConstructorWithTwitterErrorSucceeds()
+        {
+            var errors = new List<Error>
+            {
+                JsonConvert.DeserializeObject<Error>("{\r\n  \"Code\": \"401\",\r\n  \"Message\": \"Unauthorized\"\r\n}")
+            };
+
+            var twitterError = new TwitterError
+            {
+                Errors = errors
+            };
+
+            var result = new Result<bool>(twitterError);
+
+            Assert.IsFalse(result.Success);
+            Assert.AreEqual(twitterError, result.Error);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR adds unit tests to cover the [Result](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Result.cs) class of Twitter Adapter.

### Detailed Changes
- Created _ResultTests_ class and added three new tests to cover the class's constructors and properties.
- Added xUnit dependency on the project.

## Testing
This image shows the new tests passing and the resulting code coverage.

![image](https://user-images.githubusercontent.com/44245136/91494138-c537f400-e88e-11ea-8d6d-72d441a20285.png)
 
