### PR TITLE
[Twitter Adapter] Add unit tests for TwitterAdapter class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
@@ -79,16 +80,52 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
         }
 
         [TestMethod]
+        public async Task SendActivitiesAsyncShouldReturnEmptyResponsesWithActivities()
+        {
+            var options = new TwitterOptions
+            {
+                WebhookUri = "uri",
+                AccessSecret = "access-secret",
+                AccessToken = "access-token",
+                ConsumerKey = "consumer-key",
+                ConsumerSecret = "consumer-secret",
+                Environment = "env",
+                Tier = TwitterAccountApi.PremiumFree
+            };
+
+            _testOptions.SetupGet(x => x.Value).Returns(options);
+
+            var adapter = new TwitterAdapter(_testOptions.Object);
+            var activity = new Activity();
+
+            using (var turnContext = new TurnContext(adapter, activity))
+            {
+                var activities = new List<Activity>()
+                {
+                    new Activity()
+                    {
+                        Type =  ActivityTypes.Message,
+                        Text = "Test",
+                        Recipient = new ChannelAccount(),
+                    }
+                };
+
+                var result = await adapter.SendActivitiesAsync(turnContext, activities: activities.ToArray(), default);
+                Assert.IsTrue(result.Length > 0);
+            }
+        }
+
+        [TestMethod]
         public async Task UpdateActivityAsyncShouldReturnNotSupportedException()
         {
             var adapter = new TwitterAdapter(_testOptions.Object);
             var activity = new Activity();
-            
+
             using (var turnContext = new TurnContext(adapter, activity))
             {
                 await Assert.ThrowsExceptionAsync<NotSupportedException>(async () =>
                 {
-                   await adapter.UpdateActivityAsync(turnContext, activity, default);
+                    await adapter.UpdateActivityAsync(turnContext, activity, default);
                 });
             }
         }

--- a/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs
@@ -80,7 +80,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
         }
 
         [TestMethod]
-        public async Task SendActivitiesAsyncShouldReturnEmptyResponsesWithActivities()
+        public async Task SendActivitiesAsyncShouldReturnResponseWithActivity()
         {
             var options = new TwitterOptions
             {
@@ -104,6 +104,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
                 {
                     new Activity()
                     {
+                        Id = "3",
                         Type =  ActivityTypes.Message,
                         Text = "Test",
                         Recipient = new ChannelAccount(),
@@ -111,7 +112,8 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
                 };
 
                 var result = await adapter.SendActivitiesAsync(turnContext, activities: activities.ToArray(), default);
-                Assert.IsTrue(result.Length > 0);
+                Assert.IsTrue(result.Length == 1);
+                Assert.IsTrue(result[0].Id == "3");
             }
         }
 

--- a/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs
@@ -112,8 +112,8 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
                 };
 
                 var result = await adapter.SendActivitiesAsync(turnContext, activities: activities.ToArray(), default);
-                Assert.IsTrue(result.Length == 1);
-                Assert.IsTrue(result[0].Id == "3");
+                Assert.AreEqual(1, result.Length);
+                Assert.AreEqual("3", result[0].Id);
             }
         }
 

--- a/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,34 +11,33 @@ using Castle.Core.Internal;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class TwitterAdapterTests
     {
         private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
 
-        [TestMethod]
+        [Fact]
         public void ConstructorWithOptionsSucceeds()
         {
-            Assert.IsNotNull(new TwitterAdapter(_testOptions.Object));
+            Assert.NotNull(new TwitterAdapter(_testOptions.Object));
         }
 
-        [TestMethod]
+        [Fact]
         public void UseWithMiddlewareShouldSucceed()
         {
             var adapter = new TwitterAdapter(_testOptions.Object);
             var middleware = new Mock<IMiddleware>();
             var result = adapter.Use(middleware.Object);
 
-            Assert.IsFalse(result.MiddlewareSet.IsNullOrEmpty());
+            Assert.False(result.MiddlewareSet.IsNullOrEmpty());
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ProcessActivityShouldSucceed()
         {
             var adapter = new TwitterAdapter(_testOptions.Object);
@@ -55,18 +57,18 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
             bot.Verify(b => b.OnTurnAsync(It.IsAny<TurnContext>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task ProcessActivityShouldReturnNullReferenceException()
         {
             var adapter = new TwitterAdapter(_testOptions.Object);
 
-            await Assert.ThrowsExceptionAsync<NullReferenceException>(async () =>
+            await Assert.ThrowsAsync<NullReferenceException>(async () =>
             {
                 await adapter.ProcessActivity(null, null);
             });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SendActivitiesAsyncShouldReturnEmptyResponsesWithEmptyActivities()
         {
             var adapter = new TwitterAdapter(_testOptions.Object);
@@ -75,11 +77,11 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
             using (var turnContext = new TurnContext(adapter, activity))
             {
                 var result = await adapter.SendActivitiesAsync(turnContext, new Activity[0], default);
-                Assert.IsTrue(result.IsNullOrEmpty());
+                Assert.True(result.IsNullOrEmpty());
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SendActivitiesAsyncShouldReturnResponseWithActivity()
         {
             var options = new TwitterOptions
@@ -112,12 +114,12 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
                 };
 
                 var result = await adapter.SendActivitiesAsync(turnContext, activities: activities.ToArray(), default);
-                Assert.AreEqual(1, result.Length);
-                Assert.AreEqual("3", result[0].Id);
+                Assert.Single(result);
+                Assert.Equal("3", result[0].Id);
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task UpdateActivityAsyncShouldReturnNotSupportedException()
         {
             var adapter = new TwitterAdapter(_testOptions.Object);
@@ -125,14 +127,14 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
 
             using (var turnContext = new TurnContext(adapter, activity))
             {
-                await Assert.ThrowsExceptionAsync<NotSupportedException>(async () =>
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
                 {
                     await adapter.UpdateActivityAsync(turnContext, activity, default);
                 });
             }
         }
 
-        [TestMethod]
+        [Fact]
         public async Task DeleteActivityAsyncShouldReturnNotSupportedException()
         {
             var adapter = new TwitterAdapter(_testOptions.Object);
@@ -141,7 +143,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
 
             using (var turnContext = new TurnContext(adapter, activity))
             {
-                await Assert.ThrowsExceptionAsync<NotSupportedException>(async () =>
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
                 {
                     await adapter.DeleteActivityAsync(turnContext, conversationReference, default);
                 });


### PR DESCRIPTION
## Description
This PR adds a unit test for the [TwitterAdapter](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterAdapter.cs#L14) class increasing its code coverage from **81%** to **95%**.

### Specific Changes
- Updated the [TwitterAdapterTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/TwitterAdapterTests.cs#L17) file with a new unit test.
- Migrated existing tests to xUnit.

## Testing
The following images show the new test passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/91564419-007e0580-e917-11ea-9278-2de18aa6e9f1.png)
![image](https://user-images.githubusercontent.com/62260472/91496613-ce2ac480-e892-11ea-9b2e-34cbcebeb3e2.png)