### PR TITLE
[Twitter Adapter] Add unit tests for TwitterOptions class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/TwitterOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/TwitterOptionsTests.cs
@@ -28,14 +28,14 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
             Assert.AreEqual("bot-username", options.BotUsername);
             Assert.AreEqual("usernames", options.AllowedUsernames[0]);
             Assert.AreEqual(TwitterAccountApi.PremiumFree, options.Tier);
-            Assert.AreEqual(true, options.IsValid);
+            Assert.IsTrue(options.IsValid);
             Assert.AreEqual("consumer-key", options.ConsumerKey);
             Assert.AreEqual("consumer-secret", options.ConsumerSecret);
             Assert.AreEqual("access-token", options.AccessToken);
             Assert.AreEqual("access-secret", options.AccessSecret);
             Assert.AreEqual("env", options.Environment);
             Assert.AreEqual("uri", options.WebhookUri);
-            Assert.AreEqual(true, options.AllowedUsernamesConfigured());
+            Assert.IsTrue(options.AllowedUsernamesConfigured());
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/TwitterOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/TwitterOptionsTests.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class TwitterOptionsTests
     {
-        [TestMethod]
+        [Fact]
         public void TwitterOptionsPropertiesShouldBeSetSuccessfully()
         {
             var options = new TwitterOptions
@@ -25,17 +24,17 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
                 WebhookUri = "uri",
             };
 
-            Assert.AreEqual("bot-username", options.BotUsername);
-            Assert.AreEqual("usernames", options.AllowedUsernames[0]);
-            Assert.AreEqual(TwitterAccountApi.PremiumFree, options.Tier);
-            Assert.IsTrue(options.IsValid);
-            Assert.AreEqual("consumer-key", options.ConsumerKey);
-            Assert.AreEqual("consumer-secret", options.ConsumerSecret);
-            Assert.AreEqual("access-token", options.AccessToken);
-            Assert.AreEqual("access-secret", options.AccessSecret);
-            Assert.AreEqual("env", options.Environment);
-            Assert.AreEqual("uri", options.WebhookUri);
-            Assert.IsTrue(options.AllowedUsernamesConfigured());
+            Assert.Equal("bot-username", options.BotUsername);
+            Assert.Equal("usernames", options.AllowedUsernames[0]);
+            Assert.Equal(TwitterAccountApi.PremiumFree, options.Tier);
+            Assert.True(options.IsValid);
+            Assert.Equal("consumer-key", options.ConsumerKey);
+            Assert.Equal("consumer-secret", options.ConsumerSecret);
+            Assert.Equal("access-token", options.AccessToken);
+            Assert.Equal("access-secret", options.AccessSecret);
+            Assert.Equal("env", options.Environment);
+            Assert.Equal("uri", options.WebhookUri);
+            Assert.True(options.AllowedUsernamesConfigured());
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/TwitterOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/TwitterOptionsTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Castle.Core.Internal;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Options;
+using Microsoft.Rest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class TwitterOptionsTests
+    {
+        [TestMethod]
+        public async Task TwitterOptionsProperties()
+        {
+            var options = new TwitterOptions
+            {
+                BotUsername = "bot-username",
+                AllowedUsernames = new string[] { "usernames" },
+                Tier = TwitterAccountApi.PremiumFree,
+                ConsumerKey = "consumer-key",
+                ConsumerSecret = "consumer-secret",
+                AccessToken = "access-token",
+                AccessSecret = "access-secret",
+                Environment = "env",
+                WebhookUri = "uri",
+            };
+
+            Assert.AreEqual("bot-username", options.BotUsername);
+            Assert.AreEqual("usernames", options.AllowedUsernames[0]);
+            Assert.AreEqual(TwitterAccountApi.PremiumFree, options.Tier);
+            Assert.AreEqual(true, options.IsValid);
+            Assert.AreEqual("consumer-key", options.ConsumerKey);
+            Assert.AreEqual("consumer-secret", options.ConsumerSecret);
+            Assert.AreEqual("access-token", options.AccessToken);
+            Assert.AreEqual("access-secret", options.AccessSecret);
+            Assert.AreEqual("env", options.Environment);
+            Assert.AreEqual("uri", options.WebhookUri);
+            Assert.AreEqual(true, options.AllowedUsernamesConfigured());
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/TwitterOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/TwitterOptionsTests.cs
@@ -1,16 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
-using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
-using Castle.Core.Internal;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Options;
-using Microsoft.Rest;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests
 {
@@ -19,7 +10,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
     public class TwitterOptionsTests
     {
         [TestMethod]
-        public async Task TwitterOptionsProperties()
+        public void TwitterOptionsPropertiesShouldBeSetSuccessfully()
         {
             var options = new TwitterOptions
             {


### PR DESCRIPTION
## Description
This PR adds unit tests for the [TwitterOptions](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/TwitterOptions.cs#L9) class increasing its code coverage from **65%** to **100%**.

### Specific Changes
- Added the **TwitterOptionsTests** file with new unit tests.

## Testing
The following images show the new test passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/91559336-3f5b8d80-e90e-11ea-8ae2-c60e1a493976.png)