### PR TITLE
[Twitter Adapter] Add unit tests for WebhooksEnterpriseManager class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
@@ -45,7 +45,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
-            var result = await enterpriseManager.RegisterWebhook("3");
+            var result = await enterpriseManager.RegisterWebhook("webhook-url");
 
             Assert.AreEqual(89, result.Error.Errors[0].Code);
         }
@@ -63,7 +63,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
-            var result = await enterpriseManager.UnregisterWebhook("3");
+            var result = await enterpriseManager.UnregisterWebhook("webhook-id");
 
             Assert.AreEqual(89, result.Error.Errors[0].Code);
         }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -13,12 +16,59 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
     {
         private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
 
+        [TestInitialize]
+        public void SetUp()
+        {
+            var options = new TwitterOptions
+            {
+                WebhookUri = "uri",
+                AccessSecret = "access-secret",
+                AccessToken = "access-token",
+                ConsumerKey = "consumer-key",
+                ConsumerSecret = "consumer-secret",
+                Environment = "env",
+                Tier = TwitterAccountApi.PremiumFree
+            };
+
+            _testOptions.SetupGet(x => x.Value).Returns(options);
+        }
+
         [TestMethod]
         public async Task RegisterWebhookWithEmptyUrlShouldFail()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
             await Assert.ThrowsExceptionAsync<ArgumentException>(async () => { await enterpriseManager.RegisterWebhook(string.Empty); });
+        }
+
+        [TestMethod]
+        public async Task RegisterWebhookShouldReturnUnauthorized()
+        {
+            var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
+
+            var result = await enterpriseManager.RegisterWebhook("3");
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
+        }
+
+        [TestMethod]
+        public async Task UnregisterWebhookShouldReturnUnauthorized()
+        {
+            var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
+
+            var result = await enterpriseManager.UnregisterWebhook("3");
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
+        }
+
+        [TestMethod]
+        public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
+        {
+            var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
+
+            var result = await enterpriseManager.GetRegisteredWebhooks();
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
@@ -35,7 +35,6 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
-
             var result = await enterpriseManager.GetRegisteredWebhooks();
 
             Assert.Equal(89, result.Error.Errors[0].Code);
@@ -45,7 +44,6 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         public async Task RegisterWebhookShouldReturnUnauthorized()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
-
             var result = await enterpriseManager.RegisterWebhook("webhook-url");
 
             Assert.Equal(89, result.Error.Errors[0].Code);
@@ -63,7 +61,6 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         public async Task UnregisterWebhookShouldReturnUnauthorized()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
-
             var result = await enterpriseManager.UnregisterWebhook("webhook-id");
 
             Assert.Equal(89, result.Error.Errors[0].Code);

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
@@ -1,20 +1,21 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class WebhooksEnterpriseManagerTests
     {
         private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
 
-        [TestInitialize]
-        public void SetUp()
+        public WebhooksEnterpriseManagerTests()
         {
             var options = new TwitterOptions
             {
@@ -30,42 +31,42 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
             _testOptions.SetupGet(x => x.Value).Returns(options);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
             var result = await enterpriseManager.GetRegisteredWebhooks();
 
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
+            Assert.Equal(89, result.Error.Errors[0].Code);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RegisterWebhookShouldReturnUnauthorized()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
             var result = await enterpriseManager.RegisterWebhook("webhook-url");
 
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
+            Assert.Equal(89, result.Error.Errors[0].Code);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RegisterWebhookWithEmptyUrlShouldFail()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(async () => { await enterpriseManager.RegisterWebhook(string.Empty); });
+            await Assert.ThrowsAsync<ArgumentException>(async () => { await enterpriseManager.RegisterWebhook(string.Empty); });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task UnregisterWebhookShouldReturnUnauthorized()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
             var result = await enterpriseManager.UnregisterWebhook("webhook-id");
 
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
+            Assert.Equal(89, result.Error.Errors[0].Code);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs
@@ -31,11 +31,13 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         }
 
         [TestMethod]
-        public async Task RegisterWebhookWithEmptyUrlShouldFail()
+        public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(async () => { await enterpriseManager.RegisterWebhook(string.Empty); });
+            var result = await enterpriseManager.GetRegisteredWebhooks();
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
         }
 
         [TestMethod]
@@ -49,21 +51,19 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         }
 
         [TestMethod]
+        public async Task RegisterWebhookWithEmptyUrlShouldFail()
+        {
+            var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () => { await enterpriseManager.RegisterWebhook(string.Empty); });
+        }
+
+        [TestMethod]
         public async Task UnregisterWebhookShouldReturnUnauthorized()
         {
             var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
 
             var result = await enterpriseManager.UnregisterWebhook("3");
-
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
-        }
-
-        [TestMethod]
-        public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
-        {
-            var enterpriseManager = new WebhooksEnterpriseManager(_testOptions.Object.Value);
-
-            var result = await enterpriseManager.GetRegisteredWebhooks();
 
             Assert.AreEqual(89, result.Error.Errors[0].Code);
         }


### PR DESCRIPTION
## Description
This PR adds unit tests for the [WebhooksEnterpriseManager](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhooksEnterpriseManager.cs#L17) class increasing its code coverage from **14%** to **79%**.

### Specific Changes
- Updated the [WebhooksEnterpriseManagerTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksEnterpriseManagerTests.cs#L12) file with new unit tests.
- Migrated existing tests to xUnit.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/91593126-fa4b5180-e935-11ea-9e15-2068ea3dd489.png)
![image](https://user-images.githubusercontent.com/62260472/91593133-fcadab80-e935-11ea-8b21-c88ad76c771e.png)