### PR TITLE
[Twitter Adapter] Add unit tests for WebhooksPremiumManager class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
@@ -1,20 +1,21 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class WebhooksPremiumManagerTests
     {
         private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
 
-        [TestInitialize]
-        public void SetUp()
+        public WebhooksPremiumManagerTests()
         {
             var options = new TwitterOptions
             {
@@ -30,44 +31,44 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
             _testOptions.SetupGet(x => x.Value).Returns(options);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
             var result = await premiumManager.GetRegisteredWebhooks();
 
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
+            Assert.Equal(89, result.Error.Errors[0].Code);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RegisterWebhookShouldReturnUnauthorized()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
             var result = await premiumManager.RegisterWebhook("webhook-url", "env");
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
+            Assert.Equal(89, result.Error.Errors[0].Code);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task RegisterWebhookWithEmptyUrlShouldFail()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
             {
                 await premiumManager.RegisterWebhook(string.Empty, "env_test");
             });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task UnregisterWebhookShouldReturnUnauthorized()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
             var result = await premiumManager.UnregisterWebhook("webhook-id", "env");
 
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
+            Assert.Equal(89, result.Error.Errors[0].Code);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
@@ -35,7 +35,6 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
-
             var result = await premiumManager.GetRegisteredWebhooks();
 
             Assert.Equal(89, result.Error.Errors[0].Code);
@@ -45,8 +44,8 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         public async Task RegisterWebhookShouldReturnUnauthorized()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
-
             var result = await premiumManager.RegisterWebhook("webhook-url", "env");
+            
             Assert.Equal(89, result.Error.Errors[0].Code);
         }
 
@@ -55,17 +54,13 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
-            await Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                await premiumManager.RegisterWebhook(string.Empty, "env_test");
-            });
+            await Assert.ThrowsAsync<ArgumentException>(() => premiumManager.RegisterWebhook(string.Empty, "env_test"));
         }
 
         [Fact]
         public async Task UnregisterWebhookShouldReturnUnauthorized()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
-
             var result = await premiumManager.UnregisterWebhook("webhook-id", "env");
 
             Assert.Equal(89, result.Error.Errors[0].Code);

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
@@ -45,7 +45,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
-            var result = await premiumManager.RegisterWebhook("url", "environment");
+            var result = await premiumManager.RegisterWebhook("webhook-url", "env");
             Assert.AreEqual(89, result.Error.Errors[0].Code);
         }
 
@@ -56,7 +56,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
 
             await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
             {
-                await premiumManager.RegisterWebhook(string.Empty, "environment_test");
+                await premiumManager.RegisterWebhook(string.Empty, "env_test");
             });
         }
 
@@ -65,7 +65,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
-            var result = await premiumManager.UnregisterWebhook("3", "environment");
+            var result = await premiumManager.UnregisterWebhook("webhook-id", "env");
 
             Assert.AreEqual(89, result.Error.Errors[0].Code);
         }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
@@ -13,6 +13,23 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
     {
         private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
 
+        [TestInitialize]
+        public void SetUp()
+        {
+            var options = new TwitterOptions
+            {
+                WebhookUri = "uri",
+                AccessSecret = "access-secret",
+                AccessToken = "access-token",
+                ConsumerKey = "consumer-key",
+                ConsumerSecret = "consumer-secret",
+                Environment = "env",
+                Tier = TwitterAccountApi.PremiumFree
+            };
+
+            _testOptions.SetupGet(x => x.Value).Returns(options);
+        }
+
         [TestMethod]
         public async Task RegisterWebhookWithEmptyUrlShouldFail()
         {
@@ -22,6 +39,35 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
             {
                 await premiumManager.RegisterWebhook(string.Empty, "environment_test");
             });
+        }
+
+        [TestMethod]
+        public async Task RegisterWebhookShouldReturnUnauthorized()
+        {
+            var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
+
+            var result = await premiumManager.RegisterWebhook("url", "environment");
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
+        }
+
+        [TestMethod]
+        public async Task UnregisterWebhookShouldReturnUnauthorized()
+        {
+            var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
+
+            var result = await premiumManager.UnregisterWebhook("3", "environment");
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
+        }
+
+        [TestMethod]
+        public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
+        {
+            var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
+
+            var result = await premiumManager.GetRegisteredWebhooks();
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs
@@ -31,14 +31,13 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         }
 
         [TestMethod]
-        public async Task RegisterWebhookWithEmptyUrlShouldFail()
+        public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
-            {
-                await premiumManager.RegisterWebhook(string.Empty, "environment_test");
-            });
+            var result = await premiumManager.GetRegisteredWebhooks();
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
         }
 
         [TestMethod]
@@ -51,21 +50,22 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         }
 
         [TestMethod]
+        public async Task RegisterWebhookWithEmptyUrlShouldFail()
+        {
+            var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+            {
+                await premiumManager.RegisterWebhook(string.Empty, "environment_test");
+            });
+        }
+
+        [TestMethod]
         public async Task UnregisterWebhookShouldReturnUnauthorized()
         {
             var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
 
             var result = await premiumManager.UnregisterWebhook("3", "environment");
-
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
-        }
-
-        [TestMethod]
-        public async Task GetRegisteredWebhooksShouldReturnUnauthorized()
-        {
-            var premiumManager = new WebhooksPremiumManager(_testOptions.Object.Value);
-
-            var result = await premiumManager.GetRegisteredWebhooks();
 
             Assert.AreEqual(89, result.Error.Errors[0].Code);
         }


### PR DESCRIPTION
## Description
This PR adds unit tests for the [WebhooksPremiumManager ](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhooksPremiumManager.cs#L16) class increasing its code coverage from **14%** to **81%**.

### Specific Changes
- Updated the [WebhooksPremiumManagerTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhooksPremiumManagerTests.cs#L12) file with new unit tests.
- Migrated existing tests to xUnit.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/91596073-f5d56780-e93a-11ea-8394-c6564f67fc29.png)
![image](https://user-images.githubusercontent.com/62260472/91596077-f79f2b00-e93a-11ea-825f-6e7c6a32dcea.png)