### PR TITLE
[Twitter Adapter] Add unit tests for all the Webhooks/Models/Twitter files

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/EnvironmentRegistrationTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/EnvironmentRegistrationTests.cs
@@ -2,17 +2,16 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class EnvironmentRegistrationTests
     {
-        [TestMethod]
+        [Fact]
         public void EnvironmentRegistrationPropertiesShouldBeSetSuccessfully()
         {
             var environmentRegistration = new EnvironmentRegistration
@@ -23,8 +22,8 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<EnvironmentRegistration>(JsonConvert.SerializeObject(environmentRegistration));
 
-            Assert.AreEqual(environmentRegistration.Name, jsonResult.Name);
-            Assert.AreEqual(environmentRegistration.Webhooks.GetType(), jsonResult.Webhooks.GetType());
+            Assert.Equal(environmentRegistration.Name, jsonResult.Name);
+            Assert.Equal(environmentRegistration.Webhooks.GetType(), jsonResult.Webhooks.GetType());
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/EnvironmentRegistrationTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/EnvironmentRegistrationTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class EnvironmentRegistrationTests
+    {
+        [TestMethod]
+        public void EnvironmentRegistrationPropertiesShouldBeSetSuccessfully()
+        {
+            var env = new EnvironmentRegistration()
+            {
+                Name = "env-name",
+                Webhooks = new List<WebhookRegistration>()
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<EnvironmentRegistration>(JsonConvert.SerializeObject(env));
+
+            Assert.AreEqual(env.Name, jsonResult.Name);
+            Assert.AreEqual(env.Webhooks.GetType(), jsonResult.Webhooks.GetType());
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/EnvironmentRegistrationTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/EnvironmentRegistrationTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
@@ -12,16 +15,16 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void EnvironmentRegistrationPropertiesShouldBeSetSuccessfully()
         {
-            var env = new EnvironmentRegistration()
+            var environmentRegistration = new EnvironmentRegistration
             {
                 Name = "env-name",
                 Webhooks = new List<WebhookRegistration>()
             };
 
-            var jsonResult = JsonConvert.DeserializeObject<EnvironmentRegistration>(JsonConvert.SerializeObject(env));
+            var jsonResult = JsonConvert.DeserializeObject<EnvironmentRegistration>(JsonConvert.SerializeObject(environmentRegistration));
 
-            Assert.AreEqual(env.Name, jsonResult.Name);
-            Assert.AreEqual(env.Webhooks.GetType(), jsonResult.Webhooks.GetType());
+            Assert.AreEqual(environmentRegistration.Name, jsonResult.Name);
+            Assert.AreEqual(environmentRegistration.Webhooks.GetType(), jsonResult.Webhooks.GetType());
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/HashtagEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/HashtagEntityTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
@@ -10,14 +13,14 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void HashtagEntityPropertiesShouldBeSetSuccessfully()
         {
-            var hashtag = new HashtagEntity()
+            var hashtagEntity = new HashtagEntity
             {
                 text = "hashtag-text",
                 indices = new[] { 0, 1, 2 }
             };
 
-            Assert.AreEqual("hashtag-text", hashtag.text);
-            Assert.AreEqual(3, hashtag.indices.Length);
+            Assert.AreEqual("hashtag-text", hashtagEntity.text);
+            Assert.AreEqual(3, hashtagEntity.indices.Length);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/HashtagEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/HashtagEntityTests.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class HashtagEntityTests
+    {
+        [TestMethod]
+        public void HashtagEntityPropertiesShouldBeSetSuccessfully()
+        {
+            var hashtag = new HashtagEntity()
+            {
+                text = "hashtag-text",
+                indices = new[] { 0, 1, 2 }
+            };
+
+            Assert.AreEqual("hashtag-text", hashtag.text);
+            Assert.AreEqual(3, hashtag.indices.Length);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/HashtagEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/HashtagEntityTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class HashtagEntityTests
     {
-        [TestMethod]
+        [Fact]
         public void HashtagEntityPropertiesShouldBeSetSuccessfully()
         {
             var hashtagEntity = new HashtagEntity
@@ -19,8 +18,8 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 indices = new[] { 0, 1, 2 }
             };
 
-            Assert.AreEqual("hashtag-text", hashtagEntity.text);
-            Assert.AreEqual(3, hashtagEntity.indices.Length);
+            Assert.Equal("hashtag-text", hashtagEntity.text);
+            Assert.Equal(3, hashtagEntity.indices.Length);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MediaEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MediaEntityTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class MediaEntityTests
     {
-        [TestMethod]
+        [Fact]
         public void MediaEntityPropertiesShouldBeSetSuccessfully()
         {
             var mediaEntity = new MediaEntity
@@ -33,31 +32,31 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 }
             };
 
-            Assert.AreEqual(1, mediaEntity.id);
-            Assert.AreEqual("id-1", mediaEntity.id_str);
-            Assert.AreEqual("https://display-url", mediaEntity.display_url);
-            Assert.AreEqual("https://expanded-url", mediaEntity.expanded_url);
-            Assert.AreEqual("http://media-url", mediaEntity.media_url);
-            Assert.AreEqual("https://media-url", mediaEntity.media_url_https);
-            Assert.AreEqual("https://url", mediaEntity.url);
-            Assert.AreEqual("media-type", mediaEntity.type);
-            Assert.AreEqual(3, mediaEntity.indices.Length);
+            Assert.Equal(1, mediaEntity.id);
+            Assert.Equal("id-1", mediaEntity.id_str);
+            Assert.Equal("https://display-url", mediaEntity.display_url);
+            Assert.Equal("https://expanded-url", mediaEntity.expanded_url);
+            Assert.Equal("http://media-url", mediaEntity.media_url);
+            Assert.Equal("https://media-url", mediaEntity.media_url_https);
+            Assert.Equal("https://url", mediaEntity.url);
+            Assert.Equal("media-type", mediaEntity.type);
+            Assert.Equal(3, mediaEntity.indices.Length);
             // TwitterSizeThumb
-            Assert.AreEqual(128, mediaEntity.sizes.thumb.h);
-            Assert.AreEqual(72, mediaEntity.sizes.thumb.w);
-            Assert.AreEqual("resize", mediaEntity.sizes.thumb.resize);
+            Assert.Equal(128, mediaEntity.sizes.thumb.h);
+            Assert.Equal(72, mediaEntity.sizes.thumb.w);
+            Assert.Equal("resize", mediaEntity.sizes.thumb.resize);
             // TwitterSizeSmall
-            Assert.AreEqual(640, mediaEntity.sizes.small.h);
-            Assert.AreEqual(360, mediaEntity.sizes.small.w);
-            Assert.AreEqual("resize", mediaEntity.sizes.small.resize);
+            Assert.Equal(640, mediaEntity.sizes.small.h);
+            Assert.Equal(360, mediaEntity.sizes.small.w);
+            Assert.Equal("resize", mediaEntity.sizes.small.resize);
             // TwitterSizeMedium
-            Assert.AreEqual(1280, mediaEntity.sizes.medium.h);
-            Assert.AreEqual(720, mediaEntity.sizes.medium.w);
-            Assert.AreEqual("resize", mediaEntity.sizes.medium.resize);
+            Assert.Equal(1280, mediaEntity.sizes.medium.h);
+            Assert.Equal(720, mediaEntity.sizes.medium.w);
+            Assert.Equal("resize", mediaEntity.sizes.medium.resize);
             // TwitterSizeLarge
-            Assert.AreEqual(1920, mediaEntity.sizes.large.h);
-            Assert.AreEqual(1080, mediaEntity.sizes.large.w);
-            Assert.AreEqual("resize", mediaEntity.sizes.large.resize);
+            Assert.Equal(1920, mediaEntity.sizes.large.h);
+            Assert.Equal(1080, mediaEntity.sizes.large.w);
+            Assert.Equal("resize", mediaEntity.sizes.large.resize);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MediaEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MediaEntityTests.cs
@@ -41,18 +41,22 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
             Assert.Equal("https://url", mediaEntity.url);
             Assert.Equal("media-type", mediaEntity.type);
             Assert.Equal(3, mediaEntity.indices.Length);
+            
             // TwitterSizeThumb
             Assert.Equal(128, mediaEntity.sizes.thumb.h);
             Assert.Equal(72, mediaEntity.sizes.thumb.w);
             Assert.Equal("resize", mediaEntity.sizes.thumb.resize);
+            
             // TwitterSizeSmall
             Assert.Equal(640, mediaEntity.sizes.small.h);
             Assert.Equal(360, mediaEntity.sizes.small.w);
             Assert.Equal("resize", mediaEntity.sizes.small.resize);
+            
             // TwitterSizeMedium
             Assert.Equal(1280, mediaEntity.sizes.medium.h);
             Assert.Equal(720, mediaEntity.sizes.medium.w);
             Assert.Equal("resize", mediaEntity.sizes.medium.resize);
+            
             // TwitterSizeLarge
             Assert.Equal(1920, mediaEntity.sizes.large.h);
             Assert.Equal(1080, mediaEntity.sizes.large.w);

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MediaEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MediaEntityTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
@@ -10,7 +13,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void MediaEntityPropertiesShouldBeSetSuccessfully()
         {
-            var media = new MediaEntity()
+            var mediaEntity = new MediaEntity
             {
                 id = 1,
                 id_str = "id-1",
@@ -21,40 +24,40 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 url = "https://url",
                 type = "media-type",
                 indices = new[] { 0, 1, 2 },
-                sizes = new Sizes()
+                sizes = new Sizes
                 {
-                    thumb = new TwitterSizeThumb() { h = 128, w = 72, resize = "resize" },
-                    small = new TwitterSizeSmall() { h = 640, w = 360, resize = "resize" },
-                    medium = new TwitterSizeMedium() { h = 1280, w = 720, resize = "resize" },
-                    large = new TwitterSizeLarge() { h = 1920, w = 1080, resize = "resize" }
+                    thumb = new TwitterSizeThumb { h = 128, w = 72, resize = "resize" },
+                    small = new TwitterSizeSmall { h = 640, w = 360, resize = "resize" },
+                    medium = new TwitterSizeMedium { h = 1280, w = 720, resize = "resize" },
+                    large = new TwitterSizeLarge { h = 1920, w = 1080, resize = "resize" }
                 }
             };
 
-            Assert.AreEqual(1, media.id);
-            Assert.AreEqual("id-1", media.id_str);
-            Assert.AreEqual("https://display-url", media.display_url);
-            Assert.AreEqual("https://expanded-url", media.expanded_url);
-            Assert.AreEqual("http://media-url", media.media_url);
-            Assert.AreEqual("https://media-url", media.media_url_https);
-            Assert.AreEqual("https://url", media.url);
-            Assert.AreEqual("media-type", media.type);
-            Assert.AreEqual(3, media.indices.Length);
+            Assert.AreEqual(1, mediaEntity.id);
+            Assert.AreEqual("id-1", mediaEntity.id_str);
+            Assert.AreEqual("https://display-url", mediaEntity.display_url);
+            Assert.AreEqual("https://expanded-url", mediaEntity.expanded_url);
+            Assert.AreEqual("http://media-url", mediaEntity.media_url);
+            Assert.AreEqual("https://media-url", mediaEntity.media_url_https);
+            Assert.AreEqual("https://url", mediaEntity.url);
+            Assert.AreEqual("media-type", mediaEntity.type);
+            Assert.AreEqual(3, mediaEntity.indices.Length);
             // TwitterSizeThumb
-            Assert.AreEqual(128, media.sizes.thumb.h);
-            Assert.AreEqual(72, media.sizes.thumb.w);
-            Assert.AreEqual("resize", media.sizes.thumb.resize);
+            Assert.AreEqual(128, mediaEntity.sizes.thumb.h);
+            Assert.AreEqual(72, mediaEntity.sizes.thumb.w);
+            Assert.AreEqual("resize", mediaEntity.sizes.thumb.resize);
             // TwitterSizeSmall
-            Assert.AreEqual(640, media.sizes.small.h);
-            Assert.AreEqual(360, media.sizes.small.w);
-            Assert.AreEqual("resize", media.sizes.small.resize);
+            Assert.AreEqual(640, mediaEntity.sizes.small.h);
+            Assert.AreEqual(360, mediaEntity.sizes.small.w);
+            Assert.AreEqual("resize", mediaEntity.sizes.small.resize);
             // TwitterSizeMedium
-            Assert.AreEqual(1280, media.sizes.medium.h);
-            Assert.AreEqual(720, media.sizes.medium.w);
-            Assert.AreEqual("resize", media.sizes.medium.resize);
+            Assert.AreEqual(1280, mediaEntity.sizes.medium.h);
+            Assert.AreEqual(720, mediaEntity.sizes.medium.w);
+            Assert.AreEqual("resize", mediaEntity.sizes.medium.resize);
             // TwitterSizeLarge
-            Assert.AreEqual(1920, media.sizes.large.h);
-            Assert.AreEqual(1080, media.sizes.large.w);
-            Assert.AreEqual("resize", media.sizes.large.resize);
+            Assert.AreEqual(1920, mediaEntity.sizes.large.h);
+            Assert.AreEqual(1080, mediaEntity.sizes.large.w);
+            Assert.AreEqual("resize", mediaEntity.sizes.large.resize);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MediaEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MediaEntityTests.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class MediaEntityTests
+    {
+        [TestMethod]
+        public void MediaEntityPropertiesShouldBeSetSuccessfully()
+        {
+            var media = new MediaEntity()
+            {
+                id = 1,
+                id_str = "id-1",
+                display_url = "https://display-url",
+                expanded_url = "https://expanded-url",
+                media_url = "http://media-url",
+                media_url_https = "https://media-url",
+                url = "https://url",
+                type = "media-type",
+                indices = new[] { 0, 1, 2 },
+                sizes = new Sizes()
+                {
+                    thumb = new TwitterSizeThumb() { h = 128, w = 72, resize = "resize" },
+                    small = new TwitterSizeSmall() { h = 640, w = 360, resize = "resize" },
+                    medium = new TwitterSizeMedium() { h = 1280, w = 720, resize = "resize" },
+                    large = new TwitterSizeLarge() { h = 1920, w = 1080, resize = "resize" }
+                }
+            };
+
+            Assert.AreEqual(1, media.id);
+            Assert.AreEqual("id-1", media.id_str);
+            Assert.AreEqual("https://display-url", media.display_url);
+            Assert.AreEqual("https://expanded-url", media.expanded_url);
+            Assert.AreEqual("http://media-url", media.media_url);
+            Assert.AreEqual("https://media-url", media.media_url_https);
+            Assert.AreEqual("https://url", media.url);
+            Assert.AreEqual("media-type", media.type);
+            Assert.AreEqual(3, media.indices.Length);
+            // TwitterSizeThumb
+            Assert.AreEqual(128, media.sizes.thumb.h);
+            Assert.AreEqual(72, media.sizes.thumb.w);
+            Assert.AreEqual("resize", media.sizes.thumb.resize);
+            // TwitterSizeSmall
+            Assert.AreEqual(640, media.sizes.small.h);
+            Assert.AreEqual(360, media.sizes.small.w);
+            Assert.AreEqual("resize", media.sizes.small.resize);
+            // TwitterSizeMedium
+            Assert.AreEqual(1280, media.sizes.medium.h);
+            Assert.AreEqual(720, media.sizes.medium.w);
+            Assert.AreEqual("resize", media.sizes.medium.resize);
+            // TwitterSizeLarge
+            Assert.AreEqual(1920, media.sizes.large.h);
+            Assert.AreEqual(1080, media.sizes.large.w);
+            Assert.AreEqual("resize", media.sizes.large.resize);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MessageCreateTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MessageCreateTests.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class MessageCreateTests
+    {
+        [TestMethod]
+        public void MessageCreatePropertiesShouldBeSetSuccessfully()
+        {
+            var userMention = new MessageCreate()
+            {
+                id = 1,
+                id_str = "id-1",
+                created_at = "2020-09-01T15:07:18Z",
+                entities = new TwitterEntities(),
+                recipient = new TwitterFullUser(),
+                recipient_id = 1,
+                recipient_id_str = "id-1",
+                recipient_screen_name = "recipient-screen-name",
+                sender = new TwitterFullUser(),
+                sender_id = 2,
+                sender_id_str = "id-2",
+                sender_screen_name = "sender-screen-name",
+                text = "test-text"
+            };
+
+            Assert.AreEqual(1, userMention.id);
+            Assert.AreEqual("id-1", userMention.id_str);
+            Assert.AreEqual("2020-09-01T15:07:18Z", userMention.created_at);
+            Assert.AreEqual(typeof(TwitterEntities), userMention.entities.GetType());
+            Assert.AreEqual(typeof(TwitterFullUser), userMention.recipient.GetType());
+            Assert.AreEqual(1, userMention.recipient_id);
+            Assert.AreEqual("id-1", userMention.recipient_id_str);
+            Assert.AreEqual("recipient-screen-name", userMention.recipient_screen_name);
+            Assert.AreEqual(typeof(TwitterFullUser), userMention.sender.GetType());
+            Assert.AreEqual(2, userMention.sender_id);
+            Assert.AreEqual("id-2", userMention.sender_id_str);
+            Assert.AreEqual("sender-screen-name", userMention.sender_screen_name);
+            Assert.AreEqual("test-text", userMention.text);
+        }
+
+        [TestMethod]
+        public void TwitterFullUserPropertiesShouldBeSetSuccessfully()
+        {
+            var user = new TwitterFullUser()
+            {
+                id = 1,
+                id_str = "id-1",
+                created_at = "2020-09-01T15:07:18Z",
+                entities = new TwitterEntities(),
+                url = "https://url",
+                screen_name = "screen-name",
+                _protected = true,
+                contributors_enabled = true,
+                default_profile = true,
+                default_profile_image = true,
+                description = "user-description",
+                favourites_count = 3,
+                follow_request_sent = true,
+                followers_count = 13,
+                following = true,
+                friends_count = 23,
+                geo_enabled = true,
+                has_extended_profile = true,
+                is_translation_enabled = true,
+                is_translator = true,
+                lang = "en_US",
+                listed_count = 33,
+                location = "location",
+                name = "user-name",
+                notifications = true,
+                profile_background_color = "green",
+                profile_background_image_url = "http://background-image-url",
+                profile_background_image_url_https = "https://background-image-url",
+                profile_background_tile = true,
+                profile_banner_url = "https://profile-banner-url",
+                profile_image_url = "http://profile-image-url",
+                profile_image_url_https = "https://profile-image-url",
+                profile_link_color = "red",
+                profile_sidebar_border_color = "black",
+                profile_sidebar_fill_color = "white",
+                profile_text_color = "black",
+                profile_use_background_image = true,
+                statuses_count = 5,
+                time_zone = "GMT",
+                translator_type = "translator",
+                utc_offset = "-3",
+                verified = true
+            };
+
+            Assert.AreEqual(1, user.id);
+            Assert.AreEqual("id-1", user.id_str);
+            Assert.AreEqual("2020-09-01T15:07:18Z", user.created_at);
+            Assert.AreEqual(typeof(TwitterEntities), user.entities.GetType());
+            Assert.AreEqual("https://url", user.url);
+            Assert.AreEqual("screen-name", user.screen_name);
+            Assert.IsTrue(user._protected);
+            Assert.IsTrue(user.contributors_enabled);
+            Assert.IsTrue(user.default_profile);
+            Assert.IsTrue(user.default_profile_image);
+            Assert.AreEqual("user-description", user.description);
+            Assert.AreEqual(3, user.favourites_count);
+            Assert.IsTrue(user.follow_request_sent);
+            Assert.AreEqual(13, user.followers_count);
+            Assert.IsTrue(user.following);
+            Assert.AreEqual(23, user.friends_count);
+            Assert.IsTrue(user.geo_enabled);
+            Assert.IsTrue(user.has_extended_profile);
+            Assert.IsTrue(user.is_translation_enabled);
+            Assert.IsTrue(user.is_translator);
+            Assert.AreEqual("en_US", user.lang);
+            Assert.AreEqual(33, user.listed_count);
+            Assert.AreEqual("location", user.location);
+            Assert.AreEqual("user-name", user.name);
+            Assert.IsTrue(user.notifications);
+            Assert.AreEqual("green", user.profile_background_color);
+            Assert.AreEqual("http://background-image-url", user.profile_background_image_url);
+            Assert.AreEqual("https://background-image-url", user.profile_background_image_url_https);
+            Assert.IsTrue(user.profile_background_tile);
+            Assert.AreEqual("https://profile-banner-url", user.profile_banner_url);
+            Assert.AreEqual("http://profile-image-url", user.profile_image_url);
+            Assert.AreEqual("https://profile-image-url", user.profile_image_url_https);
+            Assert.AreEqual("red", user.profile_link_color);
+            Assert.AreEqual("black", user.profile_sidebar_border_color);
+            Assert.AreEqual("white", user.profile_sidebar_fill_color);
+            Assert.AreEqual("black", user.profile_text_color);
+            Assert.IsTrue(user.profile_use_background_image);
+            Assert.AreEqual(5, user.statuses_count);
+            Assert.AreEqual("GMT", user.time_zone);
+            Assert.AreEqual("translator", user.translator_type);
+            Assert.AreEqual("-3", user.utc_offset);
+            Assert.IsTrue(user.verified);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MessageCreateTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MessageCreateTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
@@ -10,7 +13,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void MessageCreatePropertiesShouldBeSetSuccessfully()
         {
-            var userMention = new MessageCreate()
+            var messageCreate = new MessageCreate
             {
                 id = 1,
                 id_str = "id-1",
@@ -27,25 +30,25 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 text = "test-text"
             };
 
-            Assert.AreEqual(1, userMention.id);
-            Assert.AreEqual("id-1", userMention.id_str);
-            Assert.AreEqual("2020-09-01T15:07:18Z", userMention.created_at);
-            Assert.AreEqual(typeof(TwitterEntities), userMention.entities.GetType());
-            Assert.AreEqual(typeof(TwitterFullUser), userMention.recipient.GetType());
-            Assert.AreEqual(1, userMention.recipient_id);
-            Assert.AreEqual("id-1", userMention.recipient_id_str);
-            Assert.AreEqual("recipient-screen-name", userMention.recipient_screen_name);
-            Assert.AreEqual(typeof(TwitterFullUser), userMention.sender.GetType());
-            Assert.AreEqual(2, userMention.sender_id);
-            Assert.AreEqual("id-2", userMention.sender_id_str);
-            Assert.AreEqual("sender-screen-name", userMention.sender_screen_name);
-            Assert.AreEqual("test-text", userMention.text);
+            Assert.AreEqual(1, messageCreate.id);
+            Assert.AreEqual("id-1", messageCreate.id_str);
+            Assert.AreEqual("2020-09-01T15:07:18Z", messageCreate.created_at);
+            Assert.AreEqual(typeof(TwitterEntities), messageCreate.entities.GetType());
+            Assert.AreEqual(typeof(TwitterFullUser), messageCreate.recipient.GetType());
+            Assert.AreEqual(1, messageCreate.recipient_id);
+            Assert.AreEqual("id-1", messageCreate.recipient_id_str);
+            Assert.AreEqual("recipient-screen-name", messageCreate.recipient_screen_name);
+            Assert.AreEqual(typeof(TwitterFullUser), messageCreate.sender.GetType());
+            Assert.AreEqual(2, messageCreate.sender_id);
+            Assert.AreEqual("id-2", messageCreate.sender_id_str);
+            Assert.AreEqual("sender-screen-name", messageCreate.sender_screen_name);
+            Assert.AreEqual("test-text", messageCreate.text);
         }
 
         [TestMethod]
         public void TwitterFullUserPropertiesShouldBeSetSuccessfully()
         {
-            var user = new TwitterFullUser()
+            var twitterFullUser = new TwitterFullUser
             {
                 id = 1,
                 id_str = "id-1",
@@ -91,48 +94,48 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 verified = true
             };
 
-            Assert.AreEqual(1, user.id);
-            Assert.AreEqual("id-1", user.id_str);
-            Assert.AreEqual("2020-09-01T15:07:18Z", user.created_at);
-            Assert.AreEqual(typeof(TwitterEntities), user.entities.GetType());
-            Assert.AreEqual("https://url", user.url);
-            Assert.AreEqual("screen-name", user.screen_name);
-            Assert.IsTrue(user._protected);
-            Assert.IsTrue(user.contributors_enabled);
-            Assert.IsTrue(user.default_profile);
-            Assert.IsTrue(user.default_profile_image);
-            Assert.AreEqual("user-description", user.description);
-            Assert.AreEqual(3, user.favourites_count);
-            Assert.IsTrue(user.follow_request_sent);
-            Assert.AreEqual(13, user.followers_count);
-            Assert.IsTrue(user.following);
-            Assert.AreEqual(23, user.friends_count);
-            Assert.IsTrue(user.geo_enabled);
-            Assert.IsTrue(user.has_extended_profile);
-            Assert.IsTrue(user.is_translation_enabled);
-            Assert.IsTrue(user.is_translator);
-            Assert.AreEqual("en_US", user.lang);
-            Assert.AreEqual(33, user.listed_count);
-            Assert.AreEqual("location", user.location);
-            Assert.AreEqual("user-name", user.name);
-            Assert.IsTrue(user.notifications);
-            Assert.AreEqual("green", user.profile_background_color);
-            Assert.AreEqual("http://background-image-url", user.profile_background_image_url);
-            Assert.AreEqual("https://background-image-url", user.profile_background_image_url_https);
-            Assert.IsTrue(user.profile_background_tile);
-            Assert.AreEqual("https://profile-banner-url", user.profile_banner_url);
-            Assert.AreEqual("http://profile-image-url", user.profile_image_url);
-            Assert.AreEqual("https://profile-image-url", user.profile_image_url_https);
-            Assert.AreEqual("red", user.profile_link_color);
-            Assert.AreEqual("black", user.profile_sidebar_border_color);
-            Assert.AreEqual("white", user.profile_sidebar_fill_color);
-            Assert.AreEqual("black", user.profile_text_color);
-            Assert.IsTrue(user.profile_use_background_image);
-            Assert.AreEqual(5, user.statuses_count);
-            Assert.AreEqual("GMT", user.time_zone);
-            Assert.AreEqual("translator", user.translator_type);
-            Assert.AreEqual("-3", user.utc_offset);
-            Assert.IsTrue(user.verified);
+            Assert.AreEqual(1, twitterFullUser.id);
+            Assert.AreEqual("id-1", twitterFullUser.id_str);
+            Assert.AreEqual("2020-09-01T15:07:18Z", twitterFullUser.created_at);
+            Assert.AreEqual(typeof(TwitterEntities), twitterFullUser.entities.GetType());
+            Assert.AreEqual("https://url", twitterFullUser.url);
+            Assert.AreEqual("screen-name", twitterFullUser.screen_name);
+            Assert.IsTrue(twitterFullUser._protected);
+            Assert.IsTrue(twitterFullUser.contributors_enabled);
+            Assert.IsTrue(twitterFullUser.default_profile);
+            Assert.IsTrue(twitterFullUser.default_profile_image);
+            Assert.AreEqual("user-description", twitterFullUser.description);
+            Assert.AreEqual(3, twitterFullUser.favourites_count);
+            Assert.IsTrue(twitterFullUser.follow_request_sent);
+            Assert.AreEqual(13, twitterFullUser.followers_count);
+            Assert.IsTrue(twitterFullUser.following);
+            Assert.AreEqual(23, twitterFullUser.friends_count);
+            Assert.IsTrue(twitterFullUser.geo_enabled);
+            Assert.IsTrue(twitterFullUser.has_extended_profile);
+            Assert.IsTrue(twitterFullUser.is_translation_enabled);
+            Assert.IsTrue(twitterFullUser.is_translator);
+            Assert.AreEqual("en_US", twitterFullUser.lang);
+            Assert.AreEqual(33, twitterFullUser.listed_count);
+            Assert.AreEqual("location", twitterFullUser.location);
+            Assert.AreEqual("user-name", twitterFullUser.name);
+            Assert.IsTrue(twitterFullUser.notifications);
+            Assert.AreEqual("green", twitterFullUser.profile_background_color);
+            Assert.AreEqual("http://background-image-url", twitterFullUser.profile_background_image_url);
+            Assert.AreEqual("https://background-image-url", twitterFullUser.profile_background_image_url_https);
+            Assert.IsTrue(twitterFullUser.profile_background_tile);
+            Assert.AreEqual("https://profile-banner-url", twitterFullUser.profile_banner_url);
+            Assert.AreEqual("http://profile-image-url", twitterFullUser.profile_image_url);
+            Assert.AreEqual("https://profile-image-url", twitterFullUser.profile_image_url_https);
+            Assert.AreEqual("red", twitterFullUser.profile_link_color);
+            Assert.AreEqual("black", twitterFullUser.profile_sidebar_border_color);
+            Assert.AreEqual("white", twitterFullUser.profile_sidebar_fill_color);
+            Assert.AreEqual("black", twitterFullUser.profile_text_color);
+            Assert.IsTrue(twitterFullUser.profile_use_background_image);
+            Assert.AreEqual(5, twitterFullUser.statuses_count);
+            Assert.AreEqual("GMT", twitterFullUser.time_zone);
+            Assert.AreEqual("translator", twitterFullUser.translator_type);
+            Assert.AreEqual("-3", twitterFullUser.utc_offset);
+            Assert.IsTrue(twitterFullUser.verified);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MessageCreateTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/MessageCreateTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class MessageCreateTests
     {
-        [TestMethod]
+        [Fact]
         public void MessageCreatePropertiesShouldBeSetSuccessfully()
         {
             var messageCreate = new MessageCreate
@@ -30,22 +29,22 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 text = "test-text"
             };
 
-            Assert.AreEqual(1, messageCreate.id);
-            Assert.AreEqual("id-1", messageCreate.id_str);
-            Assert.AreEqual("2020-09-01T15:07:18Z", messageCreate.created_at);
-            Assert.AreEqual(typeof(TwitterEntities), messageCreate.entities.GetType());
-            Assert.AreEqual(typeof(TwitterFullUser), messageCreate.recipient.GetType());
-            Assert.AreEqual(1, messageCreate.recipient_id);
-            Assert.AreEqual("id-1", messageCreate.recipient_id_str);
-            Assert.AreEqual("recipient-screen-name", messageCreate.recipient_screen_name);
-            Assert.AreEqual(typeof(TwitterFullUser), messageCreate.sender.GetType());
-            Assert.AreEqual(2, messageCreate.sender_id);
-            Assert.AreEqual("id-2", messageCreate.sender_id_str);
-            Assert.AreEqual("sender-screen-name", messageCreate.sender_screen_name);
-            Assert.AreEqual("test-text", messageCreate.text);
+            Assert.Equal(1, messageCreate.id);
+            Assert.Equal("id-1", messageCreate.id_str);
+            Assert.Equal("2020-09-01T15:07:18Z", messageCreate.created_at);
+            Assert.Equal(typeof(TwitterEntities), messageCreate.entities.GetType());
+            Assert.Equal(typeof(TwitterFullUser), messageCreate.recipient.GetType());
+            Assert.Equal(1, messageCreate.recipient_id);
+            Assert.Equal("id-1", messageCreate.recipient_id_str);
+            Assert.Equal("recipient-screen-name", messageCreate.recipient_screen_name);
+            Assert.Equal(typeof(TwitterFullUser), messageCreate.sender.GetType());
+            Assert.Equal(2, messageCreate.sender_id);
+            Assert.Equal("id-2", messageCreate.sender_id_str);
+            Assert.Equal("sender-screen-name", messageCreate.sender_screen_name);
+            Assert.Equal("test-text", messageCreate.text);
         }
 
-        [TestMethod]
+        [Fact]
         public void TwitterFullUserPropertiesShouldBeSetSuccessfully()
         {
             var twitterFullUser = new TwitterFullUser
@@ -94,48 +93,48 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 verified = true
             };
 
-            Assert.AreEqual(1, twitterFullUser.id);
-            Assert.AreEqual("id-1", twitterFullUser.id_str);
-            Assert.AreEqual("2020-09-01T15:07:18Z", twitterFullUser.created_at);
-            Assert.AreEqual(typeof(TwitterEntities), twitterFullUser.entities.GetType());
-            Assert.AreEqual("https://url", twitterFullUser.url);
-            Assert.AreEqual("screen-name", twitterFullUser.screen_name);
-            Assert.IsTrue(twitterFullUser._protected);
-            Assert.IsTrue(twitterFullUser.contributors_enabled);
-            Assert.IsTrue(twitterFullUser.default_profile);
-            Assert.IsTrue(twitterFullUser.default_profile_image);
-            Assert.AreEqual("user-description", twitterFullUser.description);
-            Assert.AreEqual(3, twitterFullUser.favourites_count);
-            Assert.IsTrue(twitterFullUser.follow_request_sent);
-            Assert.AreEqual(13, twitterFullUser.followers_count);
-            Assert.IsTrue(twitterFullUser.following);
-            Assert.AreEqual(23, twitterFullUser.friends_count);
-            Assert.IsTrue(twitterFullUser.geo_enabled);
-            Assert.IsTrue(twitterFullUser.has_extended_profile);
-            Assert.IsTrue(twitterFullUser.is_translation_enabled);
-            Assert.IsTrue(twitterFullUser.is_translator);
-            Assert.AreEqual("en_US", twitterFullUser.lang);
-            Assert.AreEqual(33, twitterFullUser.listed_count);
-            Assert.AreEqual("location", twitterFullUser.location);
-            Assert.AreEqual("user-name", twitterFullUser.name);
-            Assert.IsTrue(twitterFullUser.notifications);
-            Assert.AreEqual("green", twitterFullUser.profile_background_color);
-            Assert.AreEqual("http://background-image-url", twitterFullUser.profile_background_image_url);
-            Assert.AreEqual("https://background-image-url", twitterFullUser.profile_background_image_url_https);
-            Assert.IsTrue(twitterFullUser.profile_background_tile);
-            Assert.AreEqual("https://profile-banner-url", twitterFullUser.profile_banner_url);
-            Assert.AreEqual("http://profile-image-url", twitterFullUser.profile_image_url);
-            Assert.AreEqual("https://profile-image-url", twitterFullUser.profile_image_url_https);
-            Assert.AreEqual("red", twitterFullUser.profile_link_color);
-            Assert.AreEqual("black", twitterFullUser.profile_sidebar_border_color);
-            Assert.AreEqual("white", twitterFullUser.profile_sidebar_fill_color);
-            Assert.AreEqual("black", twitterFullUser.profile_text_color);
-            Assert.IsTrue(twitterFullUser.profile_use_background_image);
-            Assert.AreEqual(5, twitterFullUser.statuses_count);
-            Assert.AreEqual("GMT", twitterFullUser.time_zone);
-            Assert.AreEqual("translator", twitterFullUser.translator_type);
-            Assert.AreEqual("-3", twitterFullUser.utc_offset);
-            Assert.IsTrue(twitterFullUser.verified);
+            Assert.Equal(1, twitterFullUser.id);
+            Assert.Equal("id-1", twitterFullUser.id_str);
+            Assert.Equal("2020-09-01T15:07:18Z", twitterFullUser.created_at);
+            Assert.Equal(typeof(TwitterEntities), twitterFullUser.entities.GetType());
+            Assert.Equal("https://url", twitterFullUser.url);
+            Assert.Equal("screen-name", twitterFullUser.screen_name);
+            Assert.True(twitterFullUser._protected);
+            Assert.True(twitterFullUser.contributors_enabled);
+            Assert.True(twitterFullUser.default_profile);
+            Assert.True(twitterFullUser.default_profile_image);
+            Assert.Equal("user-description", twitterFullUser.description);
+            Assert.Equal(3, twitterFullUser.favourites_count);
+            Assert.True(twitterFullUser.follow_request_sent);
+            Assert.Equal(13, twitterFullUser.followers_count);
+            Assert.True(twitterFullUser.following);
+            Assert.Equal(23, twitterFullUser.friends_count);
+            Assert.True(twitterFullUser.geo_enabled);
+            Assert.True(twitterFullUser.has_extended_profile);
+            Assert.True(twitterFullUser.is_translation_enabled);
+            Assert.True(twitterFullUser.is_translator);
+            Assert.Equal("en_US", twitterFullUser.lang);
+            Assert.Equal(33, twitterFullUser.listed_count);
+            Assert.Equal("location", twitterFullUser.location);
+            Assert.Equal("user-name", twitterFullUser.name);
+            Assert.True(twitterFullUser.notifications);
+            Assert.Equal("green", twitterFullUser.profile_background_color);
+            Assert.Equal("http://background-image-url", twitterFullUser.profile_background_image_url);
+            Assert.Equal("https://background-image-url", twitterFullUser.profile_background_image_url_https);
+            Assert.True(twitterFullUser.profile_background_tile);
+            Assert.Equal("https://profile-banner-url", twitterFullUser.profile_banner_url);
+            Assert.Equal("http://profile-image-url", twitterFullUser.profile_image_url);
+            Assert.Equal("https://profile-image-url", twitterFullUser.profile_image_url_https);
+            Assert.Equal("red", twitterFullUser.profile_link_color);
+            Assert.Equal("black", twitterFullUser.profile_sidebar_border_color);
+            Assert.Equal("white", twitterFullUser.profile_sidebar_fill_color);
+            Assert.Equal("black", twitterFullUser.profile_text_color);
+            Assert.True(twitterFullUser.profile_use_background_image);
+            Assert.Equal(5, twitterFullUser.statuses_count);
+            Assert.Equal("GMT", twitterFullUser.time_zone);
+            Assert.Equal("translator", twitterFullUser.translator_type);
+            Assert.Equal("-3", twitterFullUser.utc_offset);
+            Assert.True(twitterFullUser.verified);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/NewDirectMessageModelsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/NewDirectMessageModelsTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
@@ -12,72 +15,72 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void EventPropertiesShouldBeSetSuccessfully()
         {
-            var ev = new Event()
+            var twitterEvent = new Event
             {
                 EventType = "event-type",
                 MessageCreate = new NewEvent_MessageCreate()
             };
 
-            var jsonResult = JsonConvert.DeserializeObject<Event>(JsonConvert.SerializeObject(ev));
+            var jsonResult = JsonConvert.DeserializeObject<Event>(JsonConvert.SerializeObject(twitterEvent));
 
-            Assert.AreEqual(ev.EventType, jsonResult.EventType);
-            Assert.AreEqual(ev.MessageCreate.GetType(), jsonResult.MessageCreate.GetType());
+            Assert.AreEqual(twitterEvent.EventType, jsonResult.EventType);
+            Assert.AreEqual(twitterEvent.MessageCreate.GetType(), jsonResult.MessageCreate.GetType());
         }
 
         [TestMethod]
         public void NewEvent_QuickReplyPropertiesShouldBeSetSuccessfully()
         {
-            var ev = new NewEvent_QuickReply()
+            var eventQuickReply = new NewEvent_QuickReply
             {
                 Options = new List<NewEvent_QuickReplyOption>()
             };
 
-            var jsonResult = JsonConvert.DeserializeObject<NewEvent_QuickReply>(JsonConvert.SerializeObject(ev));
+            var jsonResult = JsonConvert.DeserializeObject<NewEvent_QuickReply>(JsonConvert.SerializeObject(eventQuickReply));
 
-            Assert.AreEqual(ev.Options.GetType(), jsonResult.Options.GetType());
+            Assert.AreEqual(eventQuickReply.Options.GetType(), jsonResult.Options.GetType());
         }
 
         [TestMethod]
         public void NewEvent_QuickReplyOptionPropertiesShouldBeSetSuccessfully()
         {
-            var ev = new NewEvent_QuickReplyOption()
+            var eventQuickReplyOption = new NewEvent_QuickReplyOption
             {
                 Label = "event-label"
             };
 
-            var jsonResult = JsonConvert.DeserializeObject<NewEvent_QuickReplyOption>(JsonConvert.SerializeObject(ev));
+            var jsonResult = JsonConvert.DeserializeObject<NewEvent_QuickReplyOption>(JsonConvert.SerializeObject(eventQuickReplyOption));
 
-            Assert.AreEqual(ev.Label, jsonResult.Label);
+            Assert.AreEqual(eventQuickReplyOption.Label, jsonResult.Label);
         }
 
         [TestMethod]
         public void NewEvent_MessageCreatePropertiesShouldBeSetSuccessfully()
         {
-            var ev = new NewEvent_MessageCreate()
+            var eventMessageCreate = new NewEvent_MessageCreate
             {
                 MessageData = new NewEvent_MessageData(),
                 target = new Target()
             };
 
-            var jsonResult = JsonConvert.DeserializeObject<NewEvent_MessageCreate>(JsonConvert.SerializeObject(ev));
+            var jsonResult = JsonConvert.DeserializeObject<NewEvent_MessageCreate>(JsonConvert.SerializeObject(eventMessageCreate));
 
-            Assert.AreEqual(ev.MessageData.GetType(), jsonResult.MessageData.GetType());
-            Assert.AreEqual(ev.target.GetType(), jsonResult.target.GetType());
+            Assert.AreEqual(eventMessageCreate.MessageData.GetType(), jsonResult.MessageData.GetType());
+            Assert.AreEqual(eventMessageCreate.target.GetType(), jsonResult.target.GetType());
         }
 
         [TestMethod]
         public void NewEvent_MessageDataPropertiesShouldBeSetSuccessfully()
         {
-            var ev = new NewEvent_MessageData()
+            var eventMessageData = new NewEvent_MessageData
             {
                 QuickReply = new NewEvent_QuickReply(),
                 Text = "test-text"
             };
 
-            var jsonResult = JsonConvert.DeserializeObject<NewEvent_MessageData>(JsonConvert.SerializeObject(ev));
+            var jsonResult = JsonConvert.DeserializeObject<NewEvent_MessageData>(JsonConvert.SerializeObject(eventMessageData));
 
-            Assert.AreEqual(ev.QuickReply.GetType(), jsonResult.QuickReply.GetType());
-            Assert.AreEqual(ev.Text, jsonResult.Text);
+            Assert.AreEqual(eventMessageData.QuickReply.GetType(), jsonResult.QuickReply.GetType());
+            Assert.AreEqual(eventMessageData.Text, jsonResult.Text);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/NewDirectMessageModelsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/NewDirectMessageModelsTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class NewDirectMessageModelsTests
+    {
+        [TestMethod]
+        public void EventPropertiesShouldBeSetSuccessfully()
+        {
+            var ev = new Event()
+            {
+                EventType = "event-type",
+                MessageCreate = new NewEvent_MessageCreate()
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<Event>(JsonConvert.SerializeObject(ev));
+
+            Assert.AreEqual(ev.EventType, jsonResult.EventType);
+            Assert.AreEqual(ev.MessageCreate.GetType(), jsonResult.MessageCreate.GetType());
+        }
+
+        [TestMethod]
+        public void NewEvent_QuickReplyPropertiesShouldBeSetSuccessfully()
+        {
+            var ev = new NewEvent_QuickReply()
+            {
+                Options = new List<NewEvent_QuickReplyOption>()
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<NewEvent_QuickReply>(JsonConvert.SerializeObject(ev));
+
+            Assert.AreEqual(ev.Options.GetType(), jsonResult.Options.GetType());
+        }
+
+        [TestMethod]
+        public void NewEvent_QuickReplyOptionPropertiesShouldBeSetSuccessfully()
+        {
+            var ev = new NewEvent_QuickReplyOption()
+            {
+                Label = "event-label"
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<NewEvent_QuickReplyOption>(JsonConvert.SerializeObject(ev));
+
+            Assert.AreEqual(ev.Label, jsonResult.Label);
+        }
+
+        [TestMethod]
+        public void NewEvent_MessageCreatePropertiesShouldBeSetSuccessfully()
+        {
+            var ev = new NewEvent_MessageCreate()
+            {
+                MessageData = new NewEvent_MessageData(),
+                target = new Target()
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<NewEvent_MessageCreate>(JsonConvert.SerializeObject(ev));
+
+            Assert.AreEqual(ev.MessageData.GetType(), jsonResult.MessageData.GetType());
+            Assert.AreEqual(ev.target.GetType(), jsonResult.target.GetType());
+        }
+
+        [TestMethod]
+        public void NewEvent_MessageDataPropertiesShouldBeSetSuccessfully()
+        {
+            var ev = new NewEvent_MessageData()
+            {
+                QuickReply = new NewEvent_QuickReply(),
+                Text = "test-text"
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<NewEvent_MessageData>(JsonConvert.SerializeObject(ev));
+
+            Assert.AreEqual(ev.QuickReply.GetType(), jsonResult.QuickReply.GetType());
+            Assert.AreEqual(ev.Text, jsonResult.Text);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/NewDirectMessageModelsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/NewDirectMessageModelsTests.cs
@@ -2,17 +2,16 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class NewDirectMessageModelsTests
     {
-        [TestMethod]
+        [Fact]
         public void EventPropertiesShouldBeSetSuccessfully()
         {
             var twitterEvent = new Event
@@ -23,11 +22,11 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<Event>(JsonConvert.SerializeObject(twitterEvent));
 
-            Assert.AreEqual(twitterEvent.EventType, jsonResult.EventType);
-            Assert.AreEqual(twitterEvent.MessageCreate.GetType(), jsonResult.MessageCreate.GetType());
+            Assert.Equal(twitterEvent.EventType, jsonResult.EventType);
+            Assert.Equal(twitterEvent.MessageCreate.GetType(), jsonResult.MessageCreate.GetType());
         }
 
-        [TestMethod]
+        [Fact]
         public void NewEvent_QuickReplyPropertiesShouldBeSetSuccessfully()
         {
             var eventQuickReply = new NewEvent_QuickReply
@@ -37,10 +36,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<NewEvent_QuickReply>(JsonConvert.SerializeObject(eventQuickReply));
 
-            Assert.AreEqual(eventQuickReply.Options.GetType(), jsonResult.Options.GetType());
+            Assert.Equal(eventQuickReply.Options.GetType(), jsonResult.Options.GetType());
         }
 
-        [TestMethod]
+        [Fact]
         public void NewEvent_QuickReplyOptionPropertiesShouldBeSetSuccessfully()
         {
             var eventQuickReplyOption = new NewEvent_QuickReplyOption
@@ -50,10 +49,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<NewEvent_QuickReplyOption>(JsonConvert.SerializeObject(eventQuickReplyOption));
 
-            Assert.AreEqual(eventQuickReplyOption.Label, jsonResult.Label);
+            Assert.Equal(eventQuickReplyOption.Label, jsonResult.Label);
         }
 
-        [TestMethod]
+        [Fact]
         public void NewEvent_MessageCreatePropertiesShouldBeSetSuccessfully()
         {
             var eventMessageCreate = new NewEvent_MessageCreate
@@ -64,11 +63,11 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<NewEvent_MessageCreate>(JsonConvert.SerializeObject(eventMessageCreate));
 
-            Assert.AreEqual(eventMessageCreate.MessageData.GetType(), jsonResult.MessageData.GetType());
-            Assert.AreEqual(eventMessageCreate.target.GetType(), jsonResult.target.GetType());
+            Assert.Equal(eventMessageCreate.MessageData.GetType(), jsonResult.MessageData.GetType());
+            Assert.Equal(eventMessageCreate.target.GetType(), jsonResult.target.GetType());
         }
 
-        [TestMethod]
+        [Fact]
         public void NewEvent_MessageDataPropertiesShouldBeSetSuccessfully()
         {
             var eventMessageData = new NewEvent_MessageData
@@ -79,8 +78,8 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<NewEvent_MessageData>(JsonConvert.SerializeObject(eventMessageData));
 
-            Assert.AreEqual(eventMessageData.QuickReply.GetType(), jsonResult.QuickReply.GetType());
-            Assert.AreEqual(eventMessageData.Text, jsonResult.Text);
+            Assert.Equal(eventMessageData.QuickReply.GetType(), jsonResult.QuickReply.GetType());
+            Assert.Equal(eventMessageData.Text, jsonResult.Text);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/SymbolEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/SymbolEntityTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class SymbolEntityTests
     {
-        [TestMethod]
+        [Fact]
         public void SymbolEntityPropertiesShouldBeSetSuccessfully()
         {
             var symbolEntity = new SymbolEntity
@@ -19,8 +18,8 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 indices = new[] { 0, 1, 2 }
             };
 
-            Assert.AreEqual("symbol-text", symbolEntity.text);
-            Assert.AreEqual(3, symbolEntity.indices.Length);
+            Assert.Equal("symbol-text", symbolEntity.text);
+            Assert.Equal(3, symbolEntity.indices.Length);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/SymbolEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/SymbolEntityTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
@@ -10,7 +13,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void SymbolEntityPropertiesShouldBeSetSuccessfully()
         {
-            var symbolEntity = new SymbolEntity()
+            var symbolEntity = new SymbolEntity
             {
                 text = "symbol-text",
                 indices = new[] { 0, 1, 2 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/SymbolEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/SymbolEntityTests.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class SymbolEntityTests
+    {
+        [TestMethod]
+        public void SymbolEntityPropertiesShouldBeSetSuccessfully()
+        {
+            var symbolEntity = new SymbolEntity()
+            {
+                text = "symbol-text",
+                indices = new[] { 0, 1, 2 }
+            };
+
+            Assert.AreEqual("symbol-text", symbolEntity.text);
+            Assert.AreEqual(3, symbolEntity.indices.Length);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterEntitiesTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterEntitiesTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class TwitterEntitiesTests
+    {
+        [TestMethod]
+        public void TwitterEntitiesPropertiesShouldBeSetSuccessfully()
+        {
+            var entities = new TwitterEntities()
+            {
+                media = new List<MediaEntity>(),
+                hashtags = new List<HashtagEntity>(),
+                symbols = new List<SymbolEntity>(),
+                urls = new List<UrlEntity>(),
+                user_mentions = new List<UserMentionEntity>()
+            };
+
+            Assert.AreEqual(typeof(List<MediaEntity>), entities.media.GetType());
+            Assert.AreEqual(typeof(List<HashtagEntity>), entities.hashtags.GetType());
+            Assert.AreEqual(typeof(List<SymbolEntity>), entities.symbols.GetType());
+            Assert.AreEqual(typeof(List<UrlEntity>), entities.urls.GetType());
+            Assert.AreEqual(typeof(List<UserMentionEntity>), entities.user_mentions.GetType());
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterEntitiesTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterEntitiesTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 
@@ -11,7 +14,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void TwitterEntitiesPropertiesShouldBeSetSuccessfully()
         {
-            var entities = new TwitterEntities()
+            var twitterEntities = new TwitterEntities
             {
                 media = new List<MediaEntity>(),
                 hashtags = new List<HashtagEntity>(),
@@ -20,11 +23,11 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 user_mentions = new List<UserMentionEntity>()
             };
 
-            Assert.AreEqual(typeof(List<MediaEntity>), entities.media.GetType());
-            Assert.AreEqual(typeof(List<HashtagEntity>), entities.hashtags.GetType());
-            Assert.AreEqual(typeof(List<SymbolEntity>), entities.symbols.GetType());
-            Assert.AreEqual(typeof(List<UrlEntity>), entities.urls.GetType());
-            Assert.AreEqual(typeof(List<UserMentionEntity>), entities.user_mentions.GetType());
+            Assert.AreEqual(typeof(List<MediaEntity>), twitterEntities.media.GetType());
+            Assert.AreEqual(typeof(List<HashtagEntity>), twitterEntities.hashtags.GetType());
+            Assert.AreEqual(typeof(List<SymbolEntity>), twitterEntities.symbols.GetType());
+            Assert.AreEqual(typeof(List<UrlEntity>), twitterEntities.urls.GetType());
+            Assert.AreEqual(typeof(List<UserMentionEntity>), twitterEntities.user_mentions.GetType());
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterEntitiesTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterEntitiesTests.cs
@@ -2,16 +2,15 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class TwitterEntitiesTests
     {
-        [TestMethod]
+        [Fact]
         public void TwitterEntitiesPropertiesShouldBeSetSuccessfully()
         {
             var twitterEntities = new TwitterEntities
@@ -23,11 +22,11 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 user_mentions = new List<UserMentionEntity>()
             };
 
-            Assert.AreEqual(typeof(List<MediaEntity>), twitterEntities.media.GetType());
-            Assert.AreEqual(typeof(List<HashtagEntity>), twitterEntities.hashtags.GetType());
-            Assert.AreEqual(typeof(List<SymbolEntity>), twitterEntities.symbols.GetType());
-            Assert.AreEqual(typeof(List<UrlEntity>), twitterEntities.urls.GetType());
-            Assert.AreEqual(typeof(List<UserMentionEntity>), twitterEntities.user_mentions.GetType());
+            Assert.Equal(typeof(List<MediaEntity>), twitterEntities.media.GetType());
+            Assert.Equal(typeof(List<HashtagEntity>), twitterEntities.hashtags.GetType());
+            Assert.Equal(typeof(List<SymbolEntity>), twitterEntities.symbols.GetType());
+            Assert.Equal(typeof(List<UrlEntity>), twitterEntities.urls.GetType());
+            Assert.Equal(typeof(List<UserMentionEntity>), twitterEntities.user_mentions.GetType());
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterErrorTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterErrorTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class TwitterErrorTests
+    {
+        [TestMethod]
+        public void TwitterErrorToStringShouldReturnValue()
+        {
+            var error = new TwitterError()
+            {
+                Errors = new List<Error>()
+                {
+                    new Error() { Code = 3, Message = "error-message" }
+                }
+            };
+
+            Assert.AreEqual("Error Code: 3, Error Message: error-message", error.ToString());
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterErrorTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterErrorTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 
@@ -11,11 +14,11 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void TwitterErrorToStringShouldReturnValue()
         {
-            var error = new TwitterError()
+            var error = new TwitterError
             {
-                Errors = new List<Error>()
+                Errors = new List<Error>
                 {
-                    new Error() { Code = 3, Message = "error-message" }
+                    new Error { Code = 3, Message = "error-message" }
                 }
             };
 

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterErrorTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterErrorTests.cs
@@ -2,16 +2,15 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class TwitterErrorTests
     {
-        [TestMethod]
+        [Fact]
         public void TwitterErrorToStringShouldReturnValue()
         {
             var error = new TwitterError
@@ -22,7 +21,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 }
             };
 
-            Assert.AreEqual("Error Code: 3, Error Message: error-message", error.ToString());
+            Assert.Equal("Error Code: 3, Error Message: error-message", error.ToString());
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterUserTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterUserTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using Newtonsoft.Json;
 
@@ -11,7 +14,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void TwitterUserPropertiesShouldBeSetSuccessfully()
         {
-            var user = new TwitterUser()
+            var twitterUser = new TwitterUser
             {
                 Id = "user-id",
                 Name = "user-name",
@@ -29,22 +32,22 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 Url = "https://url"
             };
 
-            var jsonResult = JsonConvert.DeserializeObject<TwitterUser>(JsonConvert.SerializeObject(user));
+            var jsonResult = JsonConvert.DeserializeObject<TwitterUser>(JsonConvert.SerializeObject(twitterUser));
 
-            Assert.AreEqual(user.Id, jsonResult.Id);
-            Assert.AreEqual(user.Name, jsonResult.Name);
-            Assert.AreEqual(user.CreatedTimestamp, jsonResult.CreatedTimestamp);
-            Assert.AreEqual(user.Description, jsonResult.Description);
-            Assert.AreEqual(user.FollowersCount, jsonResult.FollowersCount);
-            Assert.AreEqual(user.FriendsCount, jsonResult.FriendsCount);
-            Assert.AreEqual(user.IsProtected, jsonResult.IsProtected);
-            Assert.AreEqual(user.IsVerified, jsonResult.IsVerified);
-            Assert.AreEqual(user.Location, jsonResult.Location);
-            Assert.AreEqual(user.ProfileImage, jsonResult.ProfileImage);
-            Assert.AreEqual(user.ProfileImageHttps, jsonResult.ProfileImageHttps);
-            Assert.AreEqual(user.ScreenName, jsonResult.ScreenName);
-            Assert.AreEqual(user.StatusesCount, jsonResult.StatusesCount);
-            Assert.AreEqual(user.Url, jsonResult.Url);
+            Assert.AreEqual(twitterUser.Id, jsonResult.Id);
+            Assert.AreEqual(twitterUser.Name, jsonResult.Name);
+            Assert.AreEqual(twitterUser.CreatedTimestamp, jsonResult.CreatedTimestamp);
+            Assert.AreEqual(twitterUser.Description, jsonResult.Description);
+            Assert.AreEqual(twitterUser.FollowersCount, jsonResult.FollowersCount);
+            Assert.AreEqual(twitterUser.FriendsCount, jsonResult.FriendsCount);
+            Assert.AreEqual(twitterUser.IsProtected, jsonResult.IsProtected);
+            Assert.AreEqual(twitterUser.IsVerified, jsonResult.IsVerified);
+            Assert.AreEqual(twitterUser.Location, jsonResult.Location);
+            Assert.AreEqual(twitterUser.ProfileImage, jsonResult.ProfileImage);
+            Assert.AreEqual(twitterUser.ProfileImageHttps, jsonResult.ProfileImageHttps);
+            Assert.AreEqual(twitterUser.ScreenName, jsonResult.ScreenName);
+            Assert.AreEqual(twitterUser.StatusesCount, jsonResult.StatusesCount);
+            Assert.AreEqual(twitterUser.Url, jsonResult.Url);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterUserTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterUserTests.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class TwitterUserTests
     {
-        [TestMethod]
+        [Fact]
         public void TwitterUserPropertiesShouldBeSetSuccessfully()
         {
             var twitterUser = new TwitterUser
@@ -34,20 +33,20 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<TwitterUser>(JsonConvert.SerializeObject(twitterUser));
 
-            Assert.AreEqual(twitterUser.Id, jsonResult.Id);
-            Assert.AreEqual(twitterUser.Name, jsonResult.Name);
-            Assert.AreEqual(twitterUser.CreatedTimestamp, jsonResult.CreatedTimestamp);
-            Assert.AreEqual(twitterUser.Description, jsonResult.Description);
-            Assert.AreEqual(twitterUser.FollowersCount, jsonResult.FollowersCount);
-            Assert.AreEqual(twitterUser.FriendsCount, jsonResult.FriendsCount);
-            Assert.AreEqual(twitterUser.IsProtected, jsonResult.IsProtected);
-            Assert.AreEqual(twitterUser.IsVerified, jsonResult.IsVerified);
-            Assert.AreEqual(twitterUser.Location, jsonResult.Location);
-            Assert.AreEqual(twitterUser.ProfileImage, jsonResult.ProfileImage);
-            Assert.AreEqual(twitterUser.ProfileImageHttps, jsonResult.ProfileImageHttps);
-            Assert.AreEqual(twitterUser.ScreenName, jsonResult.ScreenName);
-            Assert.AreEqual(twitterUser.StatusesCount, jsonResult.StatusesCount);
-            Assert.AreEqual(twitterUser.Url, jsonResult.Url);
+            Assert.Equal(twitterUser.Id, jsonResult.Id);
+            Assert.Equal(twitterUser.Name, jsonResult.Name);
+            Assert.Equal(twitterUser.CreatedTimestamp, jsonResult.CreatedTimestamp);
+            Assert.Equal(twitterUser.Description, jsonResult.Description);
+            Assert.Equal(twitterUser.FollowersCount, jsonResult.FollowersCount);
+            Assert.Equal(twitterUser.FriendsCount, jsonResult.FriendsCount);
+            Assert.Equal(twitterUser.IsProtected, jsonResult.IsProtected);
+            Assert.Equal(twitterUser.IsVerified, jsonResult.IsVerified);
+            Assert.Equal(twitterUser.Location, jsonResult.Location);
+            Assert.Equal(twitterUser.ProfileImage, jsonResult.ProfileImage);
+            Assert.Equal(twitterUser.ProfileImageHttps, jsonResult.ProfileImageHttps);
+            Assert.Equal(twitterUser.ScreenName, jsonResult.ScreenName);
+            Assert.Equal(twitterUser.StatusesCount, jsonResult.StatusesCount);
+            Assert.Equal(twitterUser.Url, jsonResult.Url);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterUserTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/TwitterUserTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class TwitterUserTests
+    {
+        [TestMethod]
+        public void TwitterUserPropertiesShouldBeSetSuccessfully()
+        {
+            var user = new TwitterUser()
+            {
+                Id = "user-id",
+                Name = "user-name",
+                CreatedTimestamp = 3000,
+                Description = "user-description",
+                FollowersCount = 3,
+                FriendsCount = 5,
+                IsProtected = true,
+                IsVerified = true,
+                Location = "location",
+                ProfileImage = "http://profile-image",
+                ProfileImageHttps = "https://profile-image",
+                ScreenName = "screen-name",
+                StatusesCount = 7,
+                Url = "https://url"
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<TwitterUser>(JsonConvert.SerializeObject(user));
+
+            Assert.AreEqual(user.Id, jsonResult.Id);
+            Assert.AreEqual(user.Name, jsonResult.Name);
+            Assert.AreEqual(user.CreatedTimestamp, jsonResult.CreatedTimestamp);
+            Assert.AreEqual(user.Description, jsonResult.Description);
+            Assert.AreEqual(user.FollowersCount, jsonResult.FollowersCount);
+            Assert.AreEqual(user.FriendsCount, jsonResult.FriendsCount);
+            Assert.AreEqual(user.IsProtected, jsonResult.IsProtected);
+            Assert.AreEqual(user.IsVerified, jsonResult.IsVerified);
+            Assert.AreEqual(user.Location, jsonResult.Location);
+            Assert.AreEqual(user.ProfileImage, jsonResult.ProfileImage);
+            Assert.AreEqual(user.ProfileImageHttps, jsonResult.ProfileImageHttps);
+            Assert.AreEqual(user.ScreenName, jsonResult.ScreenName);
+            Assert.AreEqual(user.StatusesCount, jsonResult.StatusesCount);
+            Assert.AreEqual(user.Url, jsonResult.Url);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UrlEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UrlEntityTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class UrlEntityTests
     {
-        [TestMethod]
+        [Fact]
         public void UrlEntityPropertiesShouldBeSetSuccessfully()
         {
             var urlEntity = new UrlEntity
@@ -21,10 +20,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 indices = new[] { 0, 1, 2 }
             };
 
-            Assert.AreEqual("https://url", urlEntity.url);
-            Assert.AreEqual("https://display-url", urlEntity.display_url);
-            Assert.AreEqual("https://expanded-url", urlEntity.expanded_url);
-            Assert.AreEqual(3, urlEntity.indices.Length);
+            Assert.Equal("https://url", urlEntity.url);
+            Assert.Equal("https://display-url", urlEntity.display_url);
+            Assert.Equal("https://expanded-url", urlEntity.expanded_url);
+            Assert.Equal(3, urlEntity.indices.Length);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UrlEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UrlEntityTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
@@ -10,7 +13,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void UrlEntityPropertiesShouldBeSetSuccessfully()
         {
-            var entity = new UrlEntity()
+            var urlEntity = new UrlEntity
             {
                 url = "https://url",
                 display_url = "https://display-url",
@@ -18,10 +21,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 indices = new[] { 0, 1, 2 }
             };
 
-            Assert.AreEqual("https://url", entity.url);
-            Assert.AreEqual("https://display-url", entity.display_url);
-            Assert.AreEqual("https://expanded-url", entity.expanded_url);
-            Assert.AreEqual(3, entity.indices.Length);
+            Assert.AreEqual("https://url", urlEntity.url);
+            Assert.AreEqual("https://display-url", urlEntity.display_url);
+            Assert.AreEqual("https://expanded-url", urlEntity.expanded_url);
+            Assert.AreEqual(3, urlEntity.indices.Length);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UrlEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UrlEntityTests.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class UrlEntityTests
+    {
+        [TestMethod]
+        public void UrlEntityPropertiesShouldBeSetSuccessfully()
+        {
+            var entity = new UrlEntity()
+            {
+                url = "https://url",
+                display_url = "https://display-url",
+                expanded_url = "https://expanded-url",
+                indices = new[] { 0, 1, 2 }
+            };
+
+            Assert.AreEqual("https://url", entity.url);
+            Assert.AreEqual("https://display-url", entity.display_url);
+            Assert.AreEqual("https://expanded-url", entity.expanded_url);
+            Assert.AreEqual(3, entity.indices.Length);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UserMentionEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UserMentionEntityTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class UserMentionEntityTests
     {
-        [TestMethod]
+        [Fact]
         public void UserMentionEntityPropertiesShouldBeSetSuccessfully()
         {
             var userMention = new UserMentionEntity
@@ -22,11 +21,11 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 indices = new[] { 0, 1, 2 }
             };
 
-            Assert.AreEqual(1, userMention.id);
-            Assert.AreEqual("id-1", userMention.id_str);
-            Assert.AreEqual("user-mention-name", userMention.name);
-            Assert.AreEqual("user-mention-screen-name", userMention.screen_name);
-            Assert.AreEqual(3, userMention.indices.Length);
+            Assert.Equal(1, userMention.id);
+            Assert.Equal("id-1", userMention.id_str);
+            Assert.Equal("user-mention-name", userMention.name);
+            Assert.Equal("user-mention-screen-name", userMention.screen_name);
+            Assert.Equal(3, userMention.indices.Length);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UserMentionEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UserMentionEntityTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
@@ -10,7 +13,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void UserMentionEntityPropertiesShouldBeSetSuccessfully()
         {
-            var userMention = new UserMentionEntity()
+            var userMention = new UserMentionEntity
             {
                 id = 1,
                 id_str = "id-1",

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UserMentionEntityTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/UserMentionEntityTests.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class UserMentionEntityTests
+    {
+        [TestMethod]
+        public void UserMentionEntityPropertiesShouldBeSetSuccessfully()
+        {
+            var userMention = new UserMentionEntity()
+            {
+                id = 1,
+                id_str = "id-1",
+                name = "user-mention-name",
+                screen_name = "user-mention-screen-name",
+                indices = new[] { 0, 1, 2 }
+            };
+
+            Assert.AreEqual(1, userMention.id);
+            Assert.AreEqual("id-1", userMention.id_str);
+            Assert.AreEqual("user-mention-name", userMention.name);
+            Assert.AreEqual("user-mention-screen-name", userMention.screen_name);
+            Assert.AreEqual(3, userMention.indices.Length);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookDMResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookDMResultTests.cs
@@ -1,0 +1,166 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class WebhookDMResultTests
+    {
+        [TestMethod]
+        public void WebhookDMResultPropertiesShouldBeSetSuccessfully()
+        {
+            var webhookDmResult = new WebhookDMResult()
+            {
+                Users = new Dictionary<string, TwitterUser>(),
+                Events = new List<DMEvent>()
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<WebhookDMResult>(JsonConvert.SerializeObject(webhookDmResult));
+
+            Assert.AreEqual(webhookDmResult.Users.GetType(), jsonResult.Users.GetType());
+            Assert.AreEqual(webhookDmResult.Events.GetType(), jsonResult.Events.GetType());
+        }
+
+        [TestMethod]
+        public void WebhookDMResultShouldConvertoToDirectMessageEventSuccessfully()
+        {
+            DirectMessageEvent dmEvent = new WebhookDMResult()
+            {
+                Users = new Dictionary<string, TwitterUser>()
+                {
+                    ["sender-id"] = new TwitterUser() { Id = "sender-id" },
+                    ["recipient-id"] = new TwitterUser() { Id = "recipient-id" }
+                },
+                Events = new List<DMEvent>() {
+                    new DMEvent() {
+                        id = "event-id",
+                        type = "message_create",
+                        message_create = new Message()
+                        {
+                            message_data = new Message_Data()
+                            {
+                                text = "test-text",
+                                attachment = new Attachment()
+                                {
+                                    media = new MediaEntity()
+                                    {
+                                        id = 1
+                                    }
+                                },
+                                entities = new TwitterEntities()
+                            },
+                            sender_id = "sender-id",
+                            target = new Target() { recipient_id = "recipient-id" }
+                        }
+                    }
+                }
+            };
+
+            Assert.AreEqual("event-id", dmEvent.Id);
+            Assert.AreEqual(TwitterEventType.MessageCreate, dmEvent.Type);
+            Assert.AreEqual(1, dmEvent.MessageEntities.media[0].id);
+            Assert.AreEqual("test-text", dmEvent.MessageText);
+            Assert.AreEqual("sender-id", dmEvent.Sender.Id);
+            Assert.AreEqual("recipient-id", dmEvent.Recipient.Id);
+        }
+
+        [TestMethod]
+        public void NewDmResultPropertiesShouldBeSetSuccessfully()
+        {
+            var result = new NewDmResult()
+            {
+                @event = new DMEvent()
+            };
+
+            Assert.AreEqual(typeof(DMEvent), result.@event.GetType());
+        }
+
+        [TestMethod]
+        public void MessagePropertiesShouldBeSetSuccessfully()
+        {
+            var message = new Message()
+            {
+                target = new Target(),
+                message_data = new Message_Data(),
+                sender_id = "sender-id"
+            };
+
+            Assert.AreEqual("sender-id", message.sender_id);
+            Assert.AreEqual(typeof(Target), message.target.GetType());
+            Assert.AreEqual(typeof(Message_Data), message.message_data.GetType());
+        }
+
+        [TestMethod]
+        public void Message_DataPropertiesShouldBeSetSuccessfully()
+        {
+            var messageData = new Message_Data()
+            {
+                text = "test-text",
+                entities = new TwitterEntities(),
+                attachment = new Attachment()
+            };
+
+            Assert.AreEqual("test-text", messageData.text);
+            Assert.AreEqual(typeof(TwitterEntities), messageData.entities.GetType());
+            Assert.AreEqual(typeof(Attachment), messageData.attachment.GetType());
+        }
+
+        [TestMethod]
+        public void AtatchmentPropertiesShouldBeSetSuccessfully()
+        {
+            var attachment = new Attachment()
+            {
+                type = "attachment-type",
+                media = new MediaEntity()
+            };
+
+            Assert.AreEqual("attachment-type", attachment.type);
+            Assert.AreEqual(typeof(MediaEntity), attachment.media.GetType());
+        }
+
+
+        [TestMethod]
+        public void DmEventPropertiesShouldBeSetSuccessfully()
+        {
+            var dmEvent = new DMEvent()
+            {
+                id = "event-id",
+                type = "event-type",
+                created_timestamp = 3000,
+                message_create = new Message()
+            };
+
+            Assert.AreEqual("event-id", dmEvent.id);
+            Assert.AreEqual("event-type", dmEvent.type);
+            Assert.AreEqual(3000, dmEvent.created_timestamp);
+            Assert.AreEqual(typeof(Message), dmEvent.message_create.GetType());
+        }
+
+        [TestMethod]
+        public void DmEventInstanceShouldConvertoToDirectMessageResultSuccessfully()
+        {
+            DirectMessageResult dmResult = new DMEvent()
+            {
+                id = "event-id",
+                message_create = new Message()
+                {
+                    message_data = new Message_Data()
+                    {
+                        text = "test-text",
+                    },
+                    sender_id = "sender-id",
+                    target = new Target() { recipient_id = "recipient-id" }
+                }
+            };
+
+            Assert.AreEqual("event-id", dmResult.Id);
+            Assert.AreEqual("test-text", dmResult.MessageText);
+            Assert.AreEqual("sender-id", dmResult.SenderId);
+            Assert.AreEqual("recipient-id", dmResult.RecipientId);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookDMResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookDMResultTests.cs
@@ -1,19 +1,18 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using System.Collections.Generic;
-using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class WebhookDMResultTests
     {
-        [TestMethod]
+        [Fact]
         public void WebhookDmResultPropertiesShouldBeSetSuccessfully()
         {
             var webhookDmResult = new WebhookDMResult
@@ -24,11 +23,11 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<WebhookDMResult>(JsonConvert.SerializeObject(webhookDmResult));
 
-            Assert.AreEqual(webhookDmResult.Users.GetType(), jsonResult.Users.GetType());
-            Assert.AreEqual(webhookDmResult.Events.GetType(), jsonResult.Events.GetType());
+            Assert.Equal(webhookDmResult.Users.GetType(), jsonResult.Users.GetType());
+            Assert.Equal(webhookDmResult.Events.GetType(), jsonResult.Events.GetType());
         }
 
-        [TestMethod]
+        [Fact]
         public void WebhookDmResultShouldConvertToDirectMessageEventSuccessfully()
         {
             DirectMessageEvent dmEvent = new WebhookDMResult
@@ -64,15 +63,15 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 }
             };
 
-            Assert.AreEqual("event-id", dmEvent.Id);
-            Assert.AreEqual(TwitterEventType.MessageCreate, dmEvent.Type);
-            Assert.AreEqual(1, dmEvent.MessageEntities.media[0].id);
-            Assert.AreEqual("test-text", dmEvent.MessageText);
-            Assert.AreEqual("sender-id", dmEvent.Sender.Id);
-            Assert.AreEqual("recipient-id", dmEvent.Recipient.Id);
+            Assert.Equal("event-id", dmEvent.Id);
+            Assert.Equal(TwitterEventType.MessageCreate, dmEvent.Type);
+            Assert.Equal(1, dmEvent.MessageEntities.media[0].id);
+            Assert.Equal("test-text", dmEvent.MessageText);
+            Assert.Equal("sender-id", dmEvent.Sender.Id);
+            Assert.Equal("recipient-id", dmEvent.Recipient.Id);
         }
 
-        [TestMethod]
+        [Fact]
         public void NewDmResultPropertiesShouldBeSetSuccessfully()
         {
             var dmResult = new NewDmResult
@@ -80,10 +79,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 @event = new DMEvent()
             };
 
-            Assert.AreEqual(typeof(DMEvent), dmResult.@event.GetType());
+            Assert.Equal(typeof(DMEvent), dmResult.@event.GetType());
         }
 
-        [TestMethod]
+        [Fact]
         public void MessagePropertiesShouldBeSetSuccessfully()
         {
             var message = new Message
@@ -93,12 +92,12 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 sender_id = "sender-id"
             };
 
-            Assert.AreEqual("sender-id", message.sender_id);
-            Assert.AreEqual(typeof(Target), message.target.GetType());
-            Assert.AreEqual(typeof(Message_Data), message.message_data.GetType());
+            Assert.Equal("sender-id", message.sender_id);
+            Assert.Equal(typeof(Target), message.target.GetType());
+            Assert.Equal(typeof(Message_Data), message.message_data.GetType());
         }
 
-        [TestMethod]
+        [Fact]
         public void Message_DataPropertiesShouldBeSetSuccessfully()
         {
             var messageData = new Message_Data
@@ -108,12 +107,12 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 attachment = new Attachment()
             };
 
-            Assert.AreEqual("test-text", messageData.text);
-            Assert.AreEqual(typeof(TwitterEntities), messageData.entities.GetType());
-            Assert.AreEqual(typeof(Attachment), messageData.attachment.GetType());
+            Assert.Equal("test-text", messageData.text);
+            Assert.Equal(typeof(TwitterEntities), messageData.entities.GetType());
+            Assert.Equal(typeof(Attachment), messageData.attachment.GetType());
         }
 
-        [TestMethod]
+        [Fact]
         public void AttachmentPropertiesShouldBeSetSuccessfully()
         {
             var attachment = new Attachment
@@ -122,12 +121,12 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 media = new MediaEntity()
             };
 
-            Assert.AreEqual("attachment-type", attachment.type);
-            Assert.AreEqual(typeof(MediaEntity), attachment.media.GetType());
+            Assert.Equal("attachment-type", attachment.type);
+            Assert.Equal(typeof(MediaEntity), attachment.media.GetType());
         }
 
 
-        [TestMethod]
+        [Fact]
         public void DmEventPropertiesShouldBeSetSuccessfully()
         {
             var dmEvent = new DMEvent
@@ -138,13 +137,13 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 message_create = new Message()
             };
 
-            Assert.AreEqual("event-id", dmEvent.id);
-            Assert.AreEqual("event-type", dmEvent.type);
-            Assert.AreEqual(3000, dmEvent.created_timestamp);
-            Assert.AreEqual(typeof(Message), dmEvent.message_create.GetType());
+            Assert.Equal("event-id", dmEvent.id);
+            Assert.Equal("event-type", dmEvent.type);
+            Assert.Equal(3000, dmEvent.created_timestamp);
+            Assert.Equal(typeof(Message), dmEvent.message_create.GetType());
         }
 
-        [TestMethod]
+        [Fact]
         public void DmEventInstanceShouldConvertToDirectMessageResultSuccessfully()
         {
             DirectMessageResult dmResult = new DMEvent
@@ -161,10 +160,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 }
             };
 
-            Assert.AreEqual("event-id", dmResult.Id);
-            Assert.AreEqual("test-text", dmResult.MessageText);
-            Assert.AreEqual("sender-id", dmResult.SenderId);
-            Assert.AreEqual("recipient-id", dmResult.RecipientId);
+            Assert.Equal("event-id", dmResult.Id);
+            Assert.Equal("test-text", dmResult.MessageText);
+            Assert.Equal("sender-id", dmResult.SenderId);
+            Assert.Equal("recipient-id", dmResult.RecipientId);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookDMResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookDMResultTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using System.Collections.Generic;
 using Newtonsoft.Json;
@@ -11,9 +14,9 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
     public class WebhookDMResultTests
     {
         [TestMethod]
-        public void WebhookDMResultPropertiesShouldBeSetSuccessfully()
+        public void WebhookDmResultPropertiesShouldBeSetSuccessfully()
         {
-            var webhookDmResult = new WebhookDMResult()
+            var webhookDmResult = new WebhookDMResult
             {
                 Users = new Dictionary<string, TwitterUser>(),
                 Events = new List<DMEvent>()
@@ -26,27 +29,28 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         }
 
         [TestMethod]
-        public void WebhookDMResultShouldConvertoToDirectMessageEventSuccessfully()
+        public void WebhookDmResultShouldConvertToDirectMessageEventSuccessfully()
         {
-            DirectMessageEvent dmEvent = new WebhookDMResult()
+            DirectMessageEvent dmEvent = new WebhookDMResult
             {
-                Users = new Dictionary<string, TwitterUser>()
+                Users = new Dictionary<string, TwitterUser>
                 {
-                    ["sender-id"] = new TwitterUser() { Id = "sender-id" },
-                    ["recipient-id"] = new TwitterUser() { Id = "recipient-id" }
+                    ["sender-id"] = new TwitterUser { Id = "sender-id" },
+                    ["recipient-id"] = new TwitterUser { Id = "recipient-id" }
                 },
-                Events = new List<DMEvent>() {
-                    new DMEvent() {
+                Events = new List<DMEvent> {
+                    new DMEvent
+                    {
                         id = "event-id",
                         type = "message_create",
-                        message_create = new Message()
+                        message_create = new Message
                         {
-                            message_data = new Message_Data()
+                            message_data = new Message_Data
                             {
                                 text = "test-text",
-                                attachment = new Attachment()
+                                attachment = new Attachment
                                 {
-                                    media = new MediaEntity()
+                                    media = new MediaEntity
                                     {
                                         id = 1
                                     }
@@ -54,7 +58,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                                 entities = new TwitterEntities()
                             },
                             sender_id = "sender-id",
-                            target = new Target() { recipient_id = "recipient-id" }
+                            target = new Target { recipient_id = "recipient-id" }
                         }
                     }
                 }
@@ -71,18 +75,18 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void NewDmResultPropertiesShouldBeSetSuccessfully()
         {
-            var result = new NewDmResult()
+            var dmResult = new NewDmResult
             {
                 @event = new DMEvent()
             };
 
-            Assert.AreEqual(typeof(DMEvent), result.@event.GetType());
+            Assert.AreEqual(typeof(DMEvent), dmResult.@event.GetType());
         }
 
         [TestMethod]
         public void MessagePropertiesShouldBeSetSuccessfully()
         {
-            var message = new Message()
+            var message = new Message
             {
                 target = new Target(),
                 message_data = new Message_Data(),
@@ -97,7 +101,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void Message_DataPropertiesShouldBeSetSuccessfully()
         {
-            var messageData = new Message_Data()
+            var messageData = new Message_Data
             {
                 text = "test-text",
                 entities = new TwitterEntities(),
@@ -110,9 +114,9 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         }
 
         [TestMethod]
-        public void AtatchmentPropertiesShouldBeSetSuccessfully()
+        public void AttachmentPropertiesShouldBeSetSuccessfully()
         {
-            var attachment = new Attachment()
+            var attachment = new Attachment
             {
                 type = "attachment-type",
                 media = new MediaEntity()
@@ -126,7 +130,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void DmEventPropertiesShouldBeSetSuccessfully()
         {
-            var dmEvent = new DMEvent()
+            var dmEvent = new DMEvent
             {
                 id = "event-id",
                 type = "event-type",
@@ -141,19 +145,19 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         }
 
         [TestMethod]
-        public void DmEventInstanceShouldConvertoToDirectMessageResultSuccessfully()
+        public void DmEventInstanceShouldConvertToDirectMessageResultSuccessfully()
         {
-            DirectMessageResult dmResult = new DMEvent()
+            DirectMessageResult dmResult = new DMEvent
             {
                 id = "event-id",
-                message_create = new Message()
+                message_create = new Message
                 {
-                    message_data = new Message_Data()
+                    message_data = new Message_Data
                     {
                         text = "test-text",
                     },
                     sender_id = "sender-id",
-                    target = new Target() { recipient_id = "recipient-id" }
+                    target = new Target { recipient_id = "recipient-id" }
                 }
             };
 

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookRegistrationTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookRegistrationTests.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class WebhookRegistrationTests
     {
-        [TestMethod]
+        [Fact]
         public void WebhookRegistrationPropertiesShouldBeSetSuccessfully()
         {
             var webhookRegistration = new WebhookRegistration
@@ -24,10 +23,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<WebhookRegistration>(JsonConvert.SerializeObject(webhookRegistration));
 
-            Assert.AreEqual(webhookRegistration.Id, jsonResult.Id);
-            Assert.AreEqual(webhookRegistration.RegisteredUrl, jsonResult.RegisteredUrl);
-            Assert.AreEqual(webhookRegistration.IsValid, jsonResult.IsValid);
-            Assert.AreEqual(webhookRegistration.CreatedTimestamp, jsonResult.CreatedTimestamp);
+            Assert.Equal(webhookRegistration.Id, jsonResult.Id);
+            Assert.Equal(webhookRegistration.RegisteredUrl, jsonResult.RegisteredUrl);
+            Assert.Equal(webhookRegistration.IsValid, jsonResult.IsValid);
+            Assert.Equal(webhookRegistration.CreatedTimestamp, jsonResult.CreatedTimestamp);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookRegistrationTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookRegistrationTests.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
-using System.Linq;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
@@ -13,7 +14,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void WebhookRegistrationPropertiesShouldBeSetSuccessfully()
         {
-            var webhook = new WebhookRegistration()
+            var webhookRegistration = new WebhookRegistration
             {
                 Id = "webhook-id",
                 RegisteredUrl = "https://registered-url",
@@ -21,12 +22,12 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
                 CreatedTimestamp = 3000
             };
 
-            var jsonResult = JsonConvert.DeserializeObject<WebhookRegistration>(JsonConvert.SerializeObject(webhook));
+            var jsonResult = JsonConvert.DeserializeObject<WebhookRegistration>(JsonConvert.SerializeObject(webhookRegistration));
 
-            Assert.AreEqual(webhook.Id, jsonResult.Id);
-            Assert.AreEqual(webhook.RegisteredUrl, jsonResult.RegisteredUrl);
-            Assert.AreEqual(webhook.IsValid, jsonResult.IsValid);
-            Assert.AreEqual(webhook.CreatedTimestamp, jsonResult.CreatedTimestamp);
+            Assert.AreEqual(webhookRegistration.Id, jsonResult.Id);
+            Assert.AreEqual(webhookRegistration.RegisteredUrl, jsonResult.RegisteredUrl);
+            Assert.AreEqual(webhookRegistration.IsValid, jsonResult.IsValid);
+            Assert.AreEqual(webhookRegistration.CreatedTimestamp, jsonResult.CreatedTimestamp);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookRegistrationTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookRegistrationTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using System.Linq;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class WebhookRegistrationTests
+    {
+        [TestMethod]
+        public void WebhookRegistrationPropertiesShouldBeSetSuccessfully()
+        {
+            var webhook = new WebhookRegistration()
+            {
+                Id = "webhook-id",
+                RegisteredUrl = "https://registered-url",
+                IsValid = true,
+                CreatedTimestamp = 3000
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<WebhookRegistration>(JsonConvert.SerializeObject(webhook));
+
+            Assert.AreEqual(webhook.Id, jsonResult.Id);
+            Assert.AreEqual(webhook.RegisteredUrl, jsonResult.RegisteredUrl);
+            Assert.AreEqual(webhook.IsValid, jsonResult.IsValid);
+            Assert.AreEqual(webhook.CreatedTimestamp, jsonResult.CreatedTimestamp);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookResultTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
+{
+    [TestClass]
+    [TestCategory("Twitter")]
+    public class WebhookResultTests
+    {
+        [TestMethod]
+        public void WebhookResultPropertiesShouldBeSetSuccessfully()
+        {
+            var webhookResult = new WebhookResult()
+            {
+                Environments = new List<EnvironmentRegistration>()
+            };
+
+            var jsonResult = JsonConvert.DeserializeObject<WebhookResult>(JsonConvert.SerializeObject(webhookResult));
+            
+            Assert.AreEqual(webhookResult.Environments.GetType(), jsonResult.Environments.GetType());
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookResultTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
@@ -12,7 +15,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
         [TestMethod]
         public void WebhookResultPropertiesShouldBeSetSuccessfully()
         {
-            var webhookResult = new WebhookResult()
+            var webhookResult = new WebhookResult
             {
                 Environments = new List<EnvironmentRegistration>()
             };

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/Twitter/WebhookResultTests.cs
@@ -2,17 +2,16 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class WebhookResultTests
     {
-        [TestMethod]
+        [Fact]
         public void WebhookResultPropertiesShouldBeSetSuccessfully()
         {
             var webhookResult = new WebhookResult
@@ -22,7 +21,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models.Twitter
 
             var jsonResult = JsonConvert.DeserializeObject<WebhookResult>(JsonConvert.SerializeObject(webhookResult));
             
-            Assert.AreEqual(webhookResult.Environments.GetType(), jsonResult.Environments.GetType());
+            Assert.Equal(webhookResult.Environments.GetType(), jsonResult.Environments.GetType());
         }
     }
 }


### PR DESCRIPTION
## Description
This PR adds unit tests for all the [Webhooks/Models/Twitter](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/tree/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/Twitter) files increasing the code coverage from **8%** to **100%**.

### Specific Changes
- Added **14** files to include **26** new unit tests.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/91890528-013fd000-ec66-11ea-9ec7-bedaacbde7ab.png)
![image](https://user-images.githubusercontent.com/62260472/91890515-fb49ef00-ec65-11ea-9752-f7c7c76d88fe.png)