### PR TITLE
[Twitter Adapter] Add unit tests for DirectMessageSender class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,7 +13,24 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
     [TestCategory("Twitter")]
     public class DirectMessageSenderTests
     {
-        private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
+        private static readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
+
+        [ClassInitialize]
+        public static void Initialize(TestContext testContext)
+        {
+            var options = new TwitterOptions
+            {
+                WebhookUri = "uri",
+                AccessSecret = "access-secret",
+                AccessToken = "access-token",
+                ConsumerKey = "consumer-key",
+                ConsumerSecret = "consumer-secret",
+                Environment = "env",
+                Tier = TwitterAccountApi.PremiumFree
+            };
+
+            _testOptions.SetupGet(x => x.Value).Returns(options);
+        }
 
         [TestMethod]
         public async Task SendWithEmptyMessageShouldFail()
@@ -36,6 +54,28 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
                 {
                     await sender.Send("test", new String('a', 141));
                 }, "You can't send more than 140 char using this end point, use SendAsync instead.");
+        }
+
+        [TestMethod]
+        public async Task SendWithLongMessageShouldReturnUnauthorized()
+        {
+            var sender = new DirectMessageSender(_testOptions.Object.Value);
+
+            var result = await sender.Send("test", "text message");
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
+        }
+
+        [TestMethod]
+        public async Task SendAsyncWithLongMessageShouldReturnUnauthorized()
+        {
+            var sender = new DirectMessageSender(_testOptions.Object.Value);
+
+            var message = new NewDirectMessageObject();
+
+            var result = await sender.SendAsync(message);
+
+            Assert.AreEqual(89, result.Error.Errors[0].Code);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs
@@ -60,7 +60,6 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
         public async Task SendWithLongMessageShouldReturnUnauthorized()
         {
             var sender = new DirectMessageSender(_testOptions.Object.Value);
-
             var result = await sender.Send("test", "text message");
 
             Assert.AreEqual(89, result.Error.Errors[0].Code);
@@ -70,9 +69,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
         public async Task SendAsyncWithLongMessageShouldReturnUnauthorized()
         {
             var sender = new DirectMessageSender(_testOptions.Object.Value);
-
             var message = new NewDirectMessageObject();
-
             var result = await sender.SendAsync(message);
 
             Assert.AreEqual(89, result.Error.Errors[0].Code);

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs
@@ -4,19 +4,17 @@ using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class DirectMessageSenderTests
     {
-        private static readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
+        private static readonly Mock<IOptions<TwitterOptions>> TestOptions = new Mock<IOptions<TwitterOptions>>();
 
-        [ClassInitialize]
-        public static void Initialize(TestContext testContext)
+        public DirectMessageSenderTests()
         {
             var options = new TwitterOptions
             {
@@ -29,50 +27,50 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
                 Tier = TwitterAccountApi.PremiumFree
             };
 
-            _testOptions.SetupGet(x => x.Value).Returns(options);
+            TestOptions.SetupGet(x => x.Value).Returns(options);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SendWithEmptyMessageShouldFail()
         {
-            var sender = new DirectMessageSender(_testOptions.Object.Value);
+            var sender = new DirectMessageSender(TestOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<TwitterException>(
+            await Assert.ThrowsAsync<TwitterException>(
                 async () =>
             {
                 await sender.Send("test", string.Empty);
-            }, "You can't send an empty message.");
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SendWithLongMessageShouldFail()
         {
-            var sender = new DirectMessageSender(_testOptions.Object.Value);
+            var sender = new DirectMessageSender(TestOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<TwitterException>(
+            await Assert.ThrowsAsync<TwitterException>(
                 async () =>
                 {
                     await sender.Send("test", new String('a', 141));
-                }, "You can't send more than 140 char using this end point, use SendAsync instead.");
+                });
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SendShouldReturnUnauthorized()
         {
-            var sender = new DirectMessageSender(_testOptions.Object.Value);
+            var sender = new DirectMessageSender(TestOptions.Object.Value);
             var result = await sender.Send("test", "text message");
 
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
+            Assert.Equal(89, result.Error.Errors[0].Code);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task SendAsyncShouldReturnUnauthorized()
         {
-            var sender = new DirectMessageSender(_testOptions.Object.Value);
+            var sender = new DirectMessageSender(TestOptions.Object.Value);
             var message = new NewDirectMessageObject();
             var result = await sender.SendAsync(message);
 
-            Assert.AreEqual(89, result.Error.Errors[0].Code);
+            Assert.Equal(89, result.Error.Errors[0].Code);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs
@@ -57,7 +57,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
         }
 
         [TestMethod]
-        public async Task SendWithLongMessageShouldReturnUnauthorized()
+        public async Task SendShouldReturnUnauthorized()
         {
             var sender = new DirectMessageSender(_testOptions.Object.Value);
             var result = await sender.Send("test", "text message");
@@ -66,7 +66,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
         }
 
         [TestMethod]
-        public async Task SendAsyncWithLongMessageShouldReturnUnauthorized()
+        public async Task SendAsyncShouldReturnUnauthorized()
         {
             var sender = new DirectMessageSender(_testOptions.Object.Value);
             var message = new NewDirectMessageObject();


### PR DESCRIPTION
## Description
This PR adds unit tests for the [DirectMessageSender](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/DirectMessageSender.cs#L19) class increasing its code coverage from **23%** to **81%**.

### Specific Changes
- Updated the [DirectMessageSenderTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/DirectMessageSenderTests.cs#L13) file with new unit tests.
- Migrated existing tests to xUnit.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93252205-8ac5c680-f76b-11ea-9300-3cc54f5c6051.png)
![image](https://user-images.githubusercontent.com/62260472/93245833-484bbc00-f762-11ea-9086-8aec6f1a76cf.png)