### PR TITLE
[Twitter Adapter] Add unit tests for SubscriptionsManager class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
@@ -11,6 +11,11 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -11,11 +11,6 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/SubscriptionsManagerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/SubscriptionsManagerTests.cs
@@ -2,49 +2,78 @@
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class SubscriptionsManagerTests
     {
-        private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
+        private static readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
+        private static readonly TwitterOptions _options = new TwitterOptions
+        {
+            WebhookUri = "uri",
+            AccessSecret = "access-secret",
+            AccessToken = "access-token",
+            ConsumerKey = "consumer-key",
+            ConsumerSecret = "consumer-secret",
+            Environment = "env",
+            Tier = TwitterAccountApi.PremiumFree
+        };
 
-        [TestMethod]
+        [Fact]
         public async Task SubscribeWithEmptyEnvironmentNameShouldFail()
         {
             var subscriptionManager = new SubscriptionsManager(_testOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
-                {
-                    await subscriptionManager.Subscribe(string.Empty);
-                });
+            await Assert.ThrowsAsync<ArgumentException>(() => subscriptionManager.Subscribe(string.Empty));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task CheckSubscriptionWithEmptyEnvironmentNameShouldFail()
         {
             var subscriptionManager = new SubscriptionsManager(_testOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
-            {
-                await subscriptionManager.CheckSubscription(string.Empty);
-            });
+            await Assert.ThrowsAsync<ArgumentException>(() => subscriptionManager.CheckSubscription(string.Empty));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task UnsubscribeWithEmptyEnvironmentNameShouldFail()
         {
             var subscriptionManager = new SubscriptionsManager(_testOptions.Object.Value);
 
-            await Assert.ThrowsExceptionAsync<ArgumentException>(
-                async () =>
-            {
-                await subscriptionManager.Unsubscribe(string.Empty);
-            });
+            await Assert.ThrowsAsync<ArgumentException>(() => subscriptionManager.Unsubscribe(string.Empty));
+        }
+
+        [Fact]
+        public async Task CheckSubscriptionShouldReturnUnauthorized()
+        {
+            _testOptions.SetupGet(x => x.Value).Returns(_options);
+            var subscriptionManager = new SubscriptionsManager(_testOptions.Object.Value);
+            var result = await subscriptionManager.CheckSubscription(_testOptions.Object.Value.Environment);
+
+            Assert.Equal(89, result.Error.Errors[0].Code);
+        }
+
+        [Fact]
+        public async Task SubscribeShouldReturnUnauthorized()
+        {
+            _testOptions.SetupGet(x => x.Value).Returns(_options);
+            var subscriptionManager = new SubscriptionsManager(_testOptions.Object.Value);
+            var result = await subscriptionManager.Subscribe(_testOptions.Object.Value.Environment);
+
+            Assert.Equal(89, result.Error.Errors[0].Code);
+        }
+
+        [Fact]
+        public async Task UnsubscribeShouldReturnNotFound()
+        {
+            _testOptions.SetupGet(x => x.Value).Returns(_options);
+            var subscriptionManager = new SubscriptionsManager(_testOptions.Object.Value);
+            var result = await subscriptionManager.Unsubscribe("webhook-id");
+
+            Assert.Null(result.Error);
         }
     }
 }


### PR DESCRIPTION
## Description
This PR adds unit tests for the [SubscriptionsManager](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/SubscriptionsManager.cs#L16) class increasing its code coverage from **23%** to **81%**.

### Specific Changes
- Updated the [SubscriptionsManagerTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/SubscriptionsManagerTests.cs#L12) file with new unit tests.
- Migrated from **MSTest** to **xUnit**.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93258079-28bd8f00-f774-11ea-98a1-86dd786f868b.png)
![image](https://user-images.githubusercontent.com/62260472/93258084-2a875280-f774-11ea-8184-18d88cd22412.png)