### PR TITLE
[Twitter Adapter] Add unit tests for WebhookInterceptor class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
@@ -11,6 +11,11 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+	    <PrivateAssets>all</PrivateAssets>
+	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -11,11 +11,6 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhookInterceptorTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhookInterceptorTests.cs
@@ -1,19 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class WebhookInterceptorTests
     {
         private readonly string consumerSecret = "test";
@@ -21,27 +23,24 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
         private readonly Mock<HttpRequest> _testRequest = new Mock<HttpRequest>();
         private StringValues _testValues = new StringValues("test_values");
 
-        [TestMethod]
+        [Fact]
         public async Task InterceptIncomingRequestWithEmptyConsumerSecretShouldFail()
         {
             var interceptor = new WebhookInterceptor(string.Empty);
 
-            await Assert.ThrowsExceptionAsync<TwitterException>(async () =>
-            {
-                await interceptor.InterceptIncomingRequest(_testRequest.Object, _testAction.Object);
-            });
+            await Assert.ThrowsAsync<TwitterException>(() => interceptor.InterceptIncomingRequest(_testRequest.Object, _testAction.Object));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InterceptIncomingRequestWithEmptyRequestShouldReturnUnhandled()
         {
             var interceptor = new WebhookInterceptor(consumerSecret);
             var response = await interceptor.InterceptIncomingRequest(_testRequest.Object, _testAction.Object);
 
-            Assert.IsFalse(response.IsHandled);
+            Assert.False(response.IsHandled);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InterceptIncomingRequestGetAndEmptyCrcTokenShouldReturnUnhandled()
         {
             var interceptor = new WebhookInterceptor(consumerSecret);
@@ -49,13 +48,13 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
             request.SetupAllProperties();
             request.Object.Method = HttpMethods.Get;
             request.Object.Query = new Mock<IQueryCollection>().Object;
-            
+
             var response = await interceptor.InterceptIncomingRequest(request.Object, _testAction.Object);
 
-            Assert.IsFalse(response.IsHandled);
+            Assert.False(response.IsHandled);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InterceptIncomingRequestGetAndCrcTokenShouldReturnHandled()
         {
             var interceptor = new WebhookInterceptor(consumerSecret);
@@ -66,10 +65,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
 
             var response = await interceptor.InterceptIncomingRequest(request.Object, _testAction.Object);
 
-            Assert.IsTrue(response.IsHandled);
+            Assert.True(response.IsHandled);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InterceptIncomingRequestPostWithEmptyHeadersShouldReturnUnhandled()
         {
             var interceptor = new WebhookInterceptor(consumerSecret);
@@ -77,31 +76,27 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
             request.SetupAllProperties();
             request.Object.Method = HttpMethods.Post;
             request.Setup(req => req.Headers.TryGetValue("x-twitter-webhooks-signature", out _testValues)).Returns(false);
-            
+
             var response = await interceptor.InterceptIncomingRequest(request.Object, _testAction.Object);
 
-            Assert.IsFalse(response.IsHandled);
+            Assert.False(response.IsHandled);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InterceptIncomingRequestPostWithInvalidSignatureShouldFail()
         {
             var interceptor = new WebhookInterceptor(consumerSecret);
-            
+
             var request = new Mock<HttpRequest>();
             request.SetupAllProperties();
             request.Object.Method = HttpMethods.Post;
             request.Object.Body = new MemoryStream(Encoding.UTF8.GetBytes("test_body"));
             request.Setup(req => req.Headers.TryGetValue("x-twitter-webhooks-signature", out _testValues)).Returns(true);
-            
-            await Assert.ThrowsExceptionAsync<TwitterException>(
-                async () =>
-            {
-                await interceptor.InterceptIncomingRequest(request.Object, _testAction.Object);
-            }, "Invalid signature");
+
+            await Assert.ThrowsAsync<TwitterException>(() => interceptor.InterceptIncomingRequest(request.Object, _testAction.Object));
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InterceptIncomingRequestPostWithValidSignatureShouldReturnHandled()
         {
             var body = "test_body";
@@ -120,7 +115,61 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Services
 
             var response = await interceptor.InterceptIncomingRequest(request.Object, _testAction.Object);
 
-            Assert.IsTrue(response.IsHandled);
+            _testAction.Verify(e => e.Invoke(It.IsAny<DirectMessageEvent>()), Times.Never());
+            Assert.True(response.IsHandled);
+        }
+
+        [Fact]
+        public async Task InterceptIncomingRequestWithValidPayloadShouldExecuteOnDirectMessageRecievedInvoke()
+        {
+            var webhookDmResult = new WebhookDMResult
+            {
+                Users = new Dictionary<string, TwitterUser>
+                {
+                    ["sender-id"] = new TwitterUser { Id = "sender-id" },
+                    ["recipient-id"] = new TwitterUser { Id = "recipient-id" }
+                },
+                Events = new List<DMEvent> {
+                    new DMEvent
+                    {
+                        id = "event-id",
+                        type = "message_create",
+                        message_create = new Message
+                        {
+                            message_data = new Message_Data
+                            {
+                                text = "test-text",
+                                attachment = new Attachment
+                                {
+                                    media = new MediaEntity { id = 1 }
+                                },
+                                entities = new TwitterEntities()
+                            },
+                            sender_id = "sender-id",
+                            target = new Target { recipient_id = "recipient-id" }
+                        }
+                    }
+                }
+            };
+
+            var body = JsonConvert.SerializeObject(webhookDmResult);
+            var interceptor = new WebhookInterceptor(consumerSecret);
+            var hashKeyArray = Encoding.UTF8.GetBytes(consumerSecret);
+            var hmacSha256Alg = new HMACSHA256(hashKeyArray);
+            var computedHash = hmacSha256Alg.ComputeHash(Encoding.UTF8.GetBytes(body));
+            var localHashedSignature = $"sha256={Convert.ToBase64String(computedHash)}";
+            var values = new StringValues(localHashedSignature);
+
+            var request = new Mock<HttpRequest>();
+            request.SetupAllProperties();
+            request.Object.Method = HttpMethods.Post;
+            request.Object.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+            request.Setup(req => req.Headers.TryGetValue("x-twitter-webhooks-signature", out values)).Returns(true);
+
+            var response = await interceptor.InterceptIncomingRequest(request.Object, _testAction.Object);
+
+            _testAction.Verify(e => e.Invoke(It.IsAny<DirectMessageEvent>()), Times.Once());
+            Assert.True(response.IsHandled);
         }
     }
 }


### PR DESCRIPTION
## Description
This PR migrates tests to xUnit and adds new tests for the [WebhookInterceptor](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Services/WebhookInterceptor.cs#L18) class increasing its code coverage from **93%** to **100%**.

### Specific Changes
- Updated the [WebhookInterceptorTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Services/WebhookInterceptorTests.cs#L17) file with new unit tests.
- Migrated from **MSTest** to **xUnit**.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93344905-9b784a00-f808-11ea-9e17-77ffac07490f.png)
![image](https://user-images.githubusercontent.com/62260472/93344916-9f0bd100-f808-11ea-9eee-b825d9f54deb.png)