### PR TITLE
[Twitter Adapter] Add unit tests for ApplicationBuilderExtensions class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/ApplicationBuilderExtensionsTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Options;
 using Moq;
-using System;
 using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests

--- a/tests/Bot.Builder.Community.Adapters.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/ApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,41 @@
+﻿
+using System;
+using Microsoft.AspNetCore.Builder;
+using Moq;
+using Xunit;
+using Microsoft.Extensions.Options;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests
+{
+    [Trait("TestCategory", "Twitter")]
+    public class ApplicationBuilderExtensionsTests
+    {
+        private static readonly Mock<IApplicationBuilder> _testApp = new Mock<IApplicationBuilder>();
+        private static readonly Mock<IServiceProvider> _testService = new Mock<IServiceProvider>();
+        private static readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
+
+        private static readonly TwitterOptions _options = new TwitterOptions
+        {
+            WebhookUri = "http://url",
+            AccessSecret = "access-secret",
+            AccessToken = "access-token",
+            ConsumerKey = "consumer-key",
+            ConsumerSecret = "consumer-secret",
+            Environment = "env",
+            Tier = TwitterAccountApi.PremiumFree
+        };
+
+        [Fact]
+        public void UseTwitterAdapterShouldCreateNewInstance()
+        {
+            _testOptions.SetupGet(e => e.Value).Returns(_options);
+            _testService.Setup(e => e.GetService(typeof(IOptions<TwitterOptions>))).Returns(_testOptions.Object);
+            _testApp.Setup(e => e.ApplicationServices).Returns(_testService.Object);
+            _testApp.Setup(e => e.New()).Returns(_testApp.Object);
+
+            _testApp.Object.UseTwitterAdapter();
+
+            _testApp.Verify(e => e.New(), Times.Once());
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/ApplicationBuilderExtensionsTests.cs
@@ -1,22 +1,22 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.AspNetCore.Builder;
-using Moq;
-using Xunit;
 using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests
 {
     [Trait("TestCategory", "Twitter")]
     public class ApplicationBuilderExtensionsTests
     {
-        private static readonly Mock<IApplicationBuilder> _testApp = new Mock<IApplicationBuilder>();
-        private static readonly Mock<IServiceProvider> _testService = new Mock<IServiceProvider>();
-        private static readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
+        private static readonly Mock<IApplicationBuilder> TestApp = new Mock<IApplicationBuilder>();
+        private static readonly Mock<IServiceProvider> TestService = new Mock<IServiceProvider>();
+        private static readonly Mock<IOptions<TwitterOptions>> TestOptions = new Mock<IOptions<TwitterOptions>>();
 
-        private static readonly TwitterOptions _options = new TwitterOptions
+        private static readonly TwitterOptions Options = new TwitterOptions
         {
             WebhookUri = "http://url",
             AccessSecret = "access-secret",
@@ -30,14 +30,14 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
         [Fact]
         public void UseTwitterAdapterShouldCreateNewInstance()
         {
-            _testOptions.SetupGet(e => e.Value).Returns(_options);
-            _testService.Setup(e => e.GetService(typeof(IOptions<TwitterOptions>))).Returns(_testOptions.Object);
-            _testApp.Setup(e => e.ApplicationServices).Returns(_testService.Object);
-            _testApp.Setup(e => e.New()).Returns(_testApp.Object);
+            TestOptions.SetupGet(e => e.Value).Returns(Options);
+            TestService.Setup(e => e.GetService(typeof(IOptions<TwitterOptions>))).Returns(TestOptions.Object);
+            TestApp.Setup(e => e.ApplicationServices).Returns(TestService.Object);
+            TestApp.Setup(e => e.New()).Returns(TestApp.Object);
 
-            _testApp.Object.UseTwitterAdapter();
+            TestApp.Object.UseTwitterAdapter();
 
-            _testApp.Verify(e => e.New(), Times.Once());
+            TestApp.Verify(e => e.New(), Times.Once());
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/ApplicationBuilderExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using Microsoft.AspNetCore.Builder;
 using Moq;


### PR DESCRIPTION
## Description
This PR adds new xUnit test for the [ApplicationBuilderExtensions](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/ApplicationBuilderExtensions.cs#L10) class increasing its code coverage from **0%** to **86%**.

### Specific Changes
- Added the ApplicationBuilderExtensionsTests file with new unit test.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93362776-cc627a00-f81c-11ea-9984-c5d8629c8008.png)
![image](https://user-images.githubusercontent.com/62260472/93362782-cd93a700-f81c-11ea-8854-80b9cb6f85b1.png)