### PR TITLE
[Twitter Adapter] Migrate unit tests to xUnit

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/ActivityExtensionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/ActivityExtensionsTests.cs
@@ -1,81 +1,83 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using Microsoft.Bot.Schema;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class ActivityExtensionsTests
     {
-        [TestMethod]
+        [Fact]
         public void AsTwitterMessageWithEmptyMessageShouldFail()
         {
-            var activity = new Activity()
+            var activity = new Activity
             {
                 Text = null,
                 Type = ActivityTypes.Message
             };
 
-            Assert.ThrowsException<TwitterException>(
+            Assert.Throws<TwitterException>(
                 () =>
             {
                 activity.AsTwitterMessage();
-            }, "You can't send an empty message.");
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public void AsTwitterMessageWithLongMessageShouldFail()
         {
-            var activity = new Activity()
+            var activity = new Activity
             {
                 Text = new string('a', 10001),
                 Type = ActivityTypes.Message
             };
 
-            Assert.ThrowsException<TwitterException>(
+            Assert.Throws<TwitterException>(
                 () =>
             {
                 activity.AsTwitterMessage();
-            }, "Invalid message, the length of the message should be less than 10000 chars.");
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public void AsTwitterMessageShouldReturnNewDirectMessage()
         {
-            var activity = new Activity()
+            var activity = new Activity
             {
                 Text = "test",
                 Type = ActivityTypes.Message,
-                Recipient = new ChannelAccount()
+                Recipient = new ChannelAccount
                 {
                     Id = null
                 }
             };
 
-            Assert.IsInstanceOfType(activity.AsTwitterMessage(), typeof(NewDirectMessageObject));
+            Assert.IsType<NewDirectMessageObject>(activity.AsTwitterMessage());
         }
 
-        [TestMethod]
+        [Fact]
         public void AsTwitterMessageShouldReturnNewDirectMessageWithQuickReply()
         {
-            var activity = new Activity()
+            var activity = new Activity
             {
                 Text = "test",
                 Type = ActivityTypes.Message,
-                Recipient = new ChannelAccount()
+                Recipient = new ChannelAccount
                 {
                     Id = null
                 },
-                SuggestedActions = new SuggestedActions()
+                SuggestedActions = new SuggestedActions
                 {
                     Actions = new List<CardAction> { new CardAction(ActionTypes.OpenUrl, "Get Started", value: "https://docs.microsoft.com/bot-framework") }
                 }
             };
 
-            Assert.IsInstanceOfType(activity.AsTwitterMessage().Event.MessageCreate.MessageData.QuickReply, typeof(NewEvent_QuickReply));
+            Assert.IsType<NewEvent_QuickReply>(activity.AsTwitterMessage().Event.MessageCreate.MessageData.QuickReply);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Bot.Builder.Community.Adapters.Twitter.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -9,8 +9,11 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Bot.Builder.Community.Adapters.Tests/Hosting/WebhookHostingServiceTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Hosting/WebhookHostingServiceTests.cs
@@ -1,34 +1,36 @@
-﻿using Bot.Builder.Community.Adapters.Twitter.Hosting;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Bot.Builder.Community.Adapters.Twitter.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Hosting
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class WebhookHostingServiceTests
     {
         private readonly Mock<ILogger<WebhookHostedService>> _testLogger = new Mock<ILogger<WebhookHostedService>>();
         private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
         private readonly Mock<IApplicationLifetime> _testAppLifetime = new Mock<IApplicationLifetime>();
 
-        [TestMethod]
+        [Fact]
         public void StartAsyncShouldComplete()
         {
             var service = new WebhookHostedService(_testAppLifetime.Object, _testOptions.Object, _testLogger.Object);
             var start = service.StartAsync(default);
-            Assert.IsTrue(start.IsCompleted);
+            Assert.True(start.IsCompleted);
         }
 
-        [TestMethod]
+        [Fact]
         public void StopAsyncShouldComplete()
         {
             var service = new WebhookHostedService(_testAppLifetime.Object, _testOptions.Object, _testLogger.Object);
             var stop = service.StopAsync(default);
-            Assert.IsTrue(stop.IsCompleted);
+            Assert.True(stop.IsCompleted);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Authentication/AuthHeaderBuilderTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Authentication/AuthHeaderBuilderTests.cs
@@ -1,40 +1,42 @@
-﻿using System.Net.Http;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.Http;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Authentication;
 using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
 using Castle.Core.Internal;
 using Microsoft.Extensions.Options;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Authentication
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class AuthHeaderBuilderTests
     {
         private readonly Mock<IOptions<TwitterOptions>> _testOptions = new Mock<IOptions<TwitterOptions>>();
 
-        [TestMethod]
+        [Fact]
         public void BuildWithNullUrlShouldFail()
         {
-            Assert.ThrowsException<TwitterException>(
+            Assert.Throws<TwitterException>(
                 () =>
             {
                 AuthHeaderBuilder.Build(_testOptions.Object.Value, HttpMethod.Post, null);
-            }, "Invalid Resource Url format.");
+            });
         }
 
-        [TestMethod]
+        [Fact]
         public void BuildWithInvalidOptionsShouldFail()
         {
-            Assert.ThrowsException<TwitterException>(
+            Assert.Throws<TwitterException>(
                 () =>
                 {
                     AuthHeaderBuilder.Build(_testOptions.Object.Value, HttpMethod.Post, "test_url");
-                }, "Invalid Twitter options.");
+                });
         }
 
-        [TestMethod]
+        [Fact]
         public void BuildWithValidOptionsAndParametersShouldReturnHeader()
         {
             var testOptions = new Mock<TwitterOptions>()
@@ -50,10 +52,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Authentication
                 }
             };
             var header = AuthHeaderBuilder.Build(testOptions.Object, HttpMethod.Get, "http://test_url.com?param1=val1&param2=val2");
-            Assert.IsFalse(header.IsNullOrEmpty());
+            Assert.False(header.IsNullOrEmpty());
         }
 
-        [TestMethod]
+        [Fact]
         public void BuildWithValidOptionsAndEmptyParametersShouldReturnHeader()
         {
             var testOptions = new Mock<TwitterOptions>()
@@ -69,7 +71,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Authentication
                 }
             };
             var header = AuthHeaderBuilder.Build(testOptions.Object, HttpMethod.Get, "test_url");
-            Assert.IsFalse(header.IsNullOrEmpty());
+            Assert.False(header.IsNullOrEmpty());
         }
     }
 }


### PR DESCRIPTION
## Description
This PR migrates existing Twitter Adapter unit tests to xUnit. 

### Detailed Changes
- Updated [ActivityExtensionsTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/ActivityExtensionsTests.cs), [WebhookHostingServiceTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/Hosting/WebhookHostingServiceTests.cs) and [AuthHeaderBuilderTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Authentication/AuthHeaderBuilderTests.cs) classes to use xUnit instead of MSTests.
- Replaced `[TestMethod]` attribute  with `[Fact]`.
- Updated Asserts.
- Replaced `[TestCategory]` attribute with `[Trait]`.

## Testing
This image shows the tests passing after the changes.
![image](https://user-images.githubusercontent.com/44245136/93376140-8ebb1c80-f82f-11ea-8afa-e2378e4c7edf.png)
