### PR TITLE
[Twitter Adapter] Add unit tests for ServiceCollectionExtensions class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests
+{
+    [Trait("TestCategory", "Twitter")]
+    public class ServiceCollectionExtensionsTests
+    {
+        private static readonly Mock<IServiceCollection> _testService = new Mock<IServiceCollection>();
+        private static readonly Mock<Action<TwitterOptions>> _testAction = new Mock<Action<TwitterOptions>>();
+
+        [Fact]
+        public void AddTwitterAdapterShouldExecuteSuccessfully()
+        {
+            _testService.Setup(e => e.Add(default));
+            _testService.Setup(e => e.GetEnumerator()).Returns(new List<ServiceDescriptor>().GetEnumerator());
+
+            _testService.Object.AddTwitterAdapter(_testAction.Object);
+
+            _testService.Verify(e => e.Add(It.IsAny<ServiceDescriptor>()));
+            _testService.Verify(e => e.GetEnumerator());
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests

--- a/tests/Bot.Builder.Community.Adapters.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests
@@ -12,19 +12,19 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests
     [Trait("TestCategory", "Twitter")]
     public class ServiceCollectionExtensionsTests
     {
-        private static readonly Mock<IServiceCollection> _testService = new Mock<IServiceCollection>();
-        private static readonly Mock<Action<TwitterOptions>> _testAction = new Mock<Action<TwitterOptions>>();
+        private static readonly Mock<IServiceCollection> TestService = new Mock<IServiceCollection>();
+        private static readonly Mock<Action<TwitterOptions>> TestAction = new Mock<Action<TwitterOptions>>();
 
         [Fact]
         public void AddTwitterAdapterShouldExecuteSuccessfully()
         {
-            _testService.Setup(e => e.Add(default));
-            _testService.Setup(e => e.GetEnumerator()).Returns(new List<ServiceDescriptor>().GetEnumerator());
+            TestService.Setup(e => e.Add(default));
+            TestService.Setup(e => e.GetEnumerator()).Returns(new List<ServiceDescriptor>().GetEnumerator());
 
-            _testService.Object.AddTwitterAdapter(_testAction.Object);
+            TestService.Object.AddTwitterAdapter(TestAction.Object);
 
-            _testService.Verify(e => e.Add(It.IsAny<ServiceDescriptor>()));
-            _testService.Verify(e => e.GetEnumerator());
+            TestService.Verify(e => e.Add(It.IsAny<ServiceDescriptor>()));
+            TestService.Verify(e => e.GetEnumerator());
         }
     }
 }


### PR DESCRIPTION
## Description
This PR adds new xUnit test for the [ServiceCollectionExtensions](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/ServiceCollectionExtensions.cs#L9) class increasing its code coverage from **0%** to **100%**.

### Specific Changes
- Added the ServiceCollectionExtensionsTests file with new unit test.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93380724-012efb00-f836-11ea-81d2-624921c552fa.png)
![image](https://user-images.githubusercontent.com/62260472/93380733-03915500-f836-11ea-9d97-25c9411f85f5.png)