### PR TITLE
[Twitter Adapter] Add unit tests for Webhooks/Models/ classes

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterEvent.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterEvent.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Bot.Builder.Community.Adapters.Twitter.Tests")]
 
 namespace Bot.Builder.Community.Adapters.Twitter.Webhooks.Models
 {

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/DirectMessageEventTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/DirectMessageEventTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models
+{
+    [Trait("TestCategory", "Twitter")]
+    public class DirectMessageEventTests
+    {
+        [Fact]
+        public void DirectMessageEventShouldBeSetSuccessfully()
+        {
+            var hashtag = new HashtagEntity
+            {
+                text = "test-hashtag"
+            };
+
+            var hashtagList = new List<HashtagEntity>
+            {
+                hashtag
+            };
+
+            var directMessage = new DirectMessageEvent
+            {
+                Recipient = new TwitterUser { Id = "test-recipient" },
+                Sender = new TwitterUser { Id = "test-sender" },
+                MessageText = "test-message",
+                MessageEntities = new TwitterEntities { hashtags = hashtagList },
+                JsonSource = "test-json"
+            };
+
+            Assert.Equal("test-recipient", directMessage.Recipient.Id);
+            Assert.Equal("test-sender", directMessage.Sender.Id);
+            Assert.Equal("test-message", directMessage.MessageText);
+            Assert.Equal(hashtagList, directMessage.MessageEntities.hashtags);
+            Assert.Equal("test-json", directMessage.JsonSource);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/DirectMessageResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/DirectMessageResultTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models
+{
+    [Trait("TestCategory", "Twitter")]
+    public class DirectMessageResultTests
+    {
+        [Fact]
+        public void DirectMessageResultShouldBeSetSuccessfully()
+        {
+            var directMessageResult = new DirectMessageResult
+            {
+                Created = DateTime.Today,
+                Id = "test-id",
+                RecipientId = "test-recipient",
+                SenderId = "test-sender",
+                MessageText = "test-message"
+            };
+
+            Assert.Equal(DateTime.Today, directMessageResult.Created);
+            Assert.Equal("test-id", directMessageResult.Id);
+            Assert.Equal("test-recipient", directMessageResult.RecipientId);
+            Assert.Equal("test-sender", directMessageResult.SenderId);
+            Assert.Equal("test-message", directMessageResult.MessageText);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/TwitterEventTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Webhooks/Models/TwitterEventTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Twitter.Tests.Webhooks.Models
+{
+    [Trait("TestCategory", "Twitter")]
+    public class TwitterEventTests
+    {
+        [Fact]
+        public void TwitterEventShouldBeSetSuccessfully()
+        {
+            var twitterEvent = new TwitterEvent
+            {
+                Id = "test-id",
+                Type = TwitterEventType.MessageCreate,
+                Created = DateTime.Today
+            };
+
+            Assert.Equal("test-id", twitterEvent.Id);
+            Assert.Equal(TwitterEventType.MessageCreate, twitterEvent.Type);
+            Assert.Equal(DateTime.Today, twitterEvent.Created);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR adds new unit test for the [TwitterEvent](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/TwitterEvent.cs),  [DirectMessageEvent](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/DirectMessageEvent.cs), and [DirectMessageResult](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Webhooks/Models/InterceptionResult.cs) classes increasing their code coverage from **0%** to **100%**.

### Specific Changes
- Added the **_TwitterEventTests_** class with a new unit test for _TwitterEvent_.
- Updated _TwitterEvent_ class adding `assembly: InternalsVisibleTo` to be able to test the internal set properties.
- Added the **_DirectMessageEventTests_** class with a new unit test for _DirectMessageEvent_.
- Added the **_DirectMessageResultTests_** class with a new unit test for _DirectMessageResult_.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/44245136/93388352-f463d480-f840-11ea-90e1-a0125e60ba2f.png)
