### PR TITLE
[Twitter Adapter] Adds unit tests for WebhookMiddleware class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Tests/Hosting/WebhookMiddlewareTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Tests/Hosting/WebhookMiddlewareTests.cs
@@ -1,21 +1,25 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Bot.Builder.Community.Adapters.Twitter.Hosting;
+using Bot.Builder.Community.Adapters.Twitter.Webhooks.Models.Twitter;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Internal;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json;
+using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Twitter.Tests.Hosting
 {
-    [TestClass]
-    [TestCategory("Twitter")]
+    [Trait("TestCategory", "Twitter")]
     public class WebhookMiddlewareTests
     {
         private readonly Mock<ILogger<WebhookMiddleware>> _testLogger = new Mock<ILogger<WebhookMiddleware>>();
@@ -24,7 +28,7 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Hosting
         private readonly Mock<RequestDelegate> _testDelegate = new Mock<RequestDelegate>();
         private StringValues _values = new StringValues("test_code");
 
-        [TestMethod]
+        [Fact]
         public async Task InvokeAsyncValidShouldSucceed()
         {
             var testOptions = new Mock<IOptions<TwitterOptions>>();
@@ -49,10 +53,10 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Hosting
 
             await middleware.InvokeAsync(context.Object, _testDelegate.Object);
 
-            Assert.AreEqual(httpResponse.Object.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, httpResponse.Object.StatusCode);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InvokeAsyncInvalidShouldLogError()
         {
             var testOptions = new Mock<IOptions<TwitterOptions>>();
@@ -78,6 +82,72 @@ namespace Bot.Builder.Community.Adapters.Twitter.Tests.Hosting
             await middleware.InvokeAsync(context.Object, _testDelegate.Object);
 
             _testLogger.Verify(x => x.Log(LogLevel.Error, 0, It.IsAny<FormattedLogValues>(), null, It.IsAny<Func<object, Exception, string>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task OnDirectMessageReceivedShouldSucceed()
+        {
+            var webhookDmResult = new WebhookDMResult
+            {
+                Users = new Dictionary<string, TwitterUser>
+                {
+                    ["sender-id"] = new TwitterUser { Id = "sender-id", ScreenName = "sender-screen-name" },
+                    ["recipient-id"] = new TwitterUser { Id = "recipient-id" }
+                },
+                Events = new List<DMEvent> {
+                    new DMEvent
+                    {
+                        id = "event-id",
+                        type = "message_create",
+                        message_create = new Message
+                        {
+                            message_data = new Message_Data
+                            {
+                                text = "test-text",
+                                attachment = new Attachment
+                                {
+                                    media = new MediaEntity { id = 1 }
+                                },
+                                entities = new TwitterEntities()
+                            },
+                            sender_id = "sender-id",
+                            target = new Target { recipient_id = "recipient-id" }
+                        }
+                    }
+                }
+            };
+
+            var testOptions = new Mock<IOptions<TwitterOptions>>();
+            testOptions.SetupGet(x => x.Value).Returns(_twitterOptions.Object);
+
+            var adapter = new TwitterAdapter(testOptions.Object);
+
+            var body = JsonConvert.SerializeObject(webhookDmResult);
+            var hashKeyArray = Encoding.UTF8.GetBytes(_twitterOptions.Object.ConsumerSecret);
+            var hmacSha256Alg = new HMACSHA256(hashKeyArray);
+            var computedHash = hmacSha256Alg.ComputeHash(Encoding.UTF8.GetBytes(body));
+            var localHashedSignature = $"sha256={Convert.ToBase64String(computedHash)}";
+            var values = new StringValues(localHashedSignature);
+
+            var request = new Mock<HttpRequest>();
+            request.SetupAllProperties();
+            request.Object.Method = HttpMethods.Post;
+            request.Object.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+            request.Setup(req => req.Headers.TryGetValue("x-twitter-webhooks-signature", out values)).Returns(true);
+
+            var httpResponse = new Mock<HttpResponse>();
+            httpResponse.SetupAllProperties();
+            httpResponse.Object.Body = new MemoryStream();
+
+            var context = new Mock<HttpContext>();
+            context.SetupGet(x => x.Response).Returns(httpResponse.Object);
+            context.SetupGet(x => x.Request).Returns(request.Object);
+
+            var middleware = new WebhookMiddleware(testOptions.Object, _testLogger.Object, _testBot.Object, adapter);
+
+            await middleware.InvokeAsync(context.Object, _testDelegate.Object);
+
+            _testBot.Verify(x => x.OnTurnAsync(It.IsAny<ITurnContext>(), default), Times.Once);
         }
     }
 }


### PR DESCRIPTION
## Description
This PR migrates tests to xUnit and adds new tests for the [WebhookMiddleware](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Twitter/Hosting/WebhookMiddleware.cs#L17) class increasing its code coverage from **69%** to **97%**.

### Specific Changes
- Updated the [WebhookMiddlewareTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Tests/Hosting/WebhookMiddlewareTests.cs#L19) file with new unit tests.
- Migrated from **MSTest** to **xUnit**.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93392137-a2be4880-f846-11ea-99d4-d53dacda31bb.png)
![image](https://user-images.githubusercontent.com/62260472/93392141-a520a280-f846-11ea-9915-0cc0bbf93323.png)