### PR TITLE
[Alexa Adapter] Add unit tests for AlexaHttpAdapter class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Integration/AspNet.Core/AlexaHttpAdapterTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Integration/AspNet.Core/AlexaHttpAdapterTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Bot.Builder.Community.Adapters.Alexa.Integration.AspNet.Core;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests.Integration.AspNet.Core
+{
+    public class AlexaHttpAdapterTests
+    {
+        private static readonly Mock<ILogger> TestLogger = new Mock<ILogger>();
+
+        [Fact]
+        public void ConstructorWithNoArgumentsShouldSucceed()
+        {
+            Assert.NotNull(new AlexaHttpAdapter());
+        }
+
+        [Fact]
+        public void ConstructorWithOptionsOnlyShouldSucceed()
+        {
+            var options = new AlexaAdapterOptions();
+            Assert.NotNull(new AlexaHttpAdapter(options));
+        }
+
+        [Fact]
+        public void ConstructorWithLoggerOnlyShouldSucceed()
+        {
+            Assert.NotNull(new AlexaHttpAdapter(null, TestLogger.Object));
+        }
+
+        [Fact]
+        public void ConstructorWithValidateRequestsOnlyShouldSucceed()
+        {
+            Assert.NotNull(new AlexaHttpAdapter(true));
+        }
+
+        [Fact]
+        public void ConstructorWithValidateRequestsAndLoggerShouldSucceed()
+        {
+            Assert.NotNull(new AlexaHttpAdapter(false, TestLogger.Object));
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR adds tests for the [AlexaHttpAdapter](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa/Integration/AspNet.Core/AlexaHttpAdapter.cs#L5) class increasing its code coverage from **0%** to **100%**.

### Specific Changes
- Added the AlexaHttpAdapterTests file with new unit test.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93488136-65a49580-f8dc-11ea-91fd-89894b985d3c.png)
![image](https://user-images.githubusercontent.com/62260472/93488150-676e5900-f8dc-11ea-8d06-4cf995515da6.png)