### PR TITLE
[Alexa Adapter] Add unit tests for AlexaRequestMapperOptions, MergedActivityResult and AlexaAttachmentContentTypes classes

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperOptionsTests.cs
@@ -9,6 +9,17 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
     public class AlexaRequestMapperOptionsTests
     {
         [Fact]
+        public void ConstructorWithDefaultValuesShouldSuccess()
+        {
+            var alexaRequestMapperOptions = new AlexaRequestMapperOptions();
+
+            Assert.Equal("alexa", alexaRequestMapperOptions.ChannelId);
+            Assert.Null(alexaRequestMapperOptions.ServiceUrl);
+            Assert.Equal("phrase", alexaRequestMapperOptions.DefaultIntentSlotName);
+            Assert.True(alexaRequestMapperOptions.ShouldEndSessionByDefault);
+        }
+
+        [Fact]
         public void AlexaRequestMapperOptionsShouldBeSetSuccessfully()
         {
             var alexaRequestMapperOptions = new AlexaRequestMapperOptions

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperOptionsTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Bot.Builder.Community.Adapters.Alexa.Core;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests
+{
+    public class AlexaRequestMapperOptionsTests
+    {
+        [Fact]
+        public void AlexaRequestMapperOptionsShouldBeSetSuccessfully()
+        {
+            var alexaRequestMapperOptions = new AlexaRequestMapperOptions
+            {
+                ChannelId = "channel-id",
+                ServiceUrl = "service-url",
+                DefaultIntentSlotName = "default-intent-slot-name",
+                ShouldEndSessionByDefault = false
+            };
+
+            Assert.Equal("channel-id", alexaRequestMapperOptions.ChannelId);
+            Assert.Equal("service-url", alexaRequestMapperOptions.ServiceUrl);
+            Assert.Equal("default-intent-slot-name", alexaRequestMapperOptions.DefaultIntentSlotName);
+            Assert.False(alexaRequestMapperOptions.ShouldEndSessionByDefault);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperOptionsTests.cs
@@ -9,7 +9,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
     public class AlexaRequestMapperOptionsTests
     {
         [Fact]
-        public void ConstructorWithDefaultValuesShouldSuccess()
+        public void ConstructorWithDefaultValuesShouldSucceed()
         {
             var alexaRequestMapperOptions = new AlexaRequestMapperOptions();
 

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Attachments/AlexaAttachmentContentTypesTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Attachments/AlexaAttachmentContentTypesTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Bot.Builder.Community.Adapters.Alexa.Core.Attachments;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests.Attachments
+{
+    public class AlexaAttachmentContentTypesTests
+    {
+        [Fact]
+        public void AlexaAttachmentContentTypesShouldBeSetSuccessfully()
+        {
+            Assert.Equal("application/vhd.bfalexa.card", AlexaAttachmentContentTypes.Card);
+            Assert.Equal("application/vhd.bfalexa.directive", AlexaAttachmentContentTypes.Directive);
+            Assert.Equal("application/vhd.bfalexa.permissionconsent", AlexaAttachmentContentTypes.PermissionConsent);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/MergedActivityResultTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/MergedActivityResultTests.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Bot.Builder.Community.Adapters.Alexa.Core;
+using Microsoft.Bot.Schema;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests
+{
+    public class MergedActivityResultTests
+    {
+        [Fact]
+        public void MergedActivityResultShouldBeSetSuccessfully()
+        {
+            var alexaRequestMapperOptions = new MergedActivityResult
+            {
+                MergedActivity = new Activity(),
+                EndOfConversationFlagged = true
+            };
+
+            Assert.IsType<Activity>(alexaRequestMapperOptions.MergedActivity);
+            Assert.True(alexaRequestMapperOptions.EndOfConversationFlagged);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR adds tests for the following classes to increase code coverage.
- [AlexaRequestMapperOptions](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapperOptions.cs#L5) increased from **83%** to **100%**.
- [MergedActivityResult](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa.Core/MergedActivityResult.cs#L8) increased from **0%** to **100%**.
- [AlexaAttachmentContentTypes](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa.Core/Attachments/AlexaAttachmentContentTypes.cs#L7) increased from **0%** to **100%**.

### Specific Changes
- Added the AlexaRequestMapperOptionsTests file with new unit test.
- Added the MergedActivityResultTests file with new unit test.
- Added the AlexaAttachmentContentTypesTests file with new unit test.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93505933-ea4dde80-f8f1-11ea-8357-ce00c8ee7b68.png)
![image](https://user-images.githubusercontent.com/62260472/93506063-15383280-f8f2-11ea-975e-f29b71636bab.png)