### PR TITLE
[AlexaAdapter] Add unit tests for AlexaAdapterOptions, TurnContextEx, and ValidationHelper classes

### DIFF
--- a/libraries/Bot.Builder.Community.Adapters.Alexa/TurnContextEx.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/TurnContextEx.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Bot.Builder;
 using Microsoft.Bot.Schema;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Bot.Builder.Community.Adapters.Alexa.Tests")]
 
 namespace Bot.Builder.Community.Adapters.Alexa
 {

--- a/libraries/Bot.Builder.Community.Adapters.Alexa/ValidationHelper.cs
+++ b/libraries/Bot.Builder.Community.Adapters.Alexa/ValidationHelper.cs
@@ -1,8 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Alexa.NET.Request;
 using Bot.Builder.Community.Adapters.Alexa.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+
+[assembly: InternalsVisibleTo("Bot.Builder.Community.Adapters.Alexa.Tests")]
 
 namespace Bot.Builder.Community.Adapters.Alexa
 {

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterOptionsTests.cs
@@ -8,7 +8,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
     public class AlexaAdapterOptionsTests
     {
         [Fact]
-        public void ConstructorWithDefaultValuesShouldSuccess()
+        public void ConstructorWithDefaultValuesShouldSucceed()
         {
             var alexaOptions = new AlexaAdapterOptions();
 
@@ -18,7 +18,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
         }
 
         [Fact]
-        public void ConstructorWithValuesShouldSuccess()
+        public void ConstructorWithValuesShouldSucceed()
         {
             var alexaOptions = new AlexaAdapterOptions
             {

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterOptionsTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterOptionsTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests
+{
+    public class AlexaAdapterOptionsTests
+    {
+        [Fact]
+        public void ConstructorWithDefaultValuesShouldSuccess()
+        {
+            var alexaOptions = new AlexaAdapterOptions();
+
+            Assert.False(alexaOptions.TryConvertFirstActivityAttachmentToAlexaCard);
+            Assert.True(alexaOptions.ValidateIncomingAlexaRequests);
+            Assert.True(alexaOptions.ShouldEndSessionByDefault);
+        }
+
+        [Fact]
+        public void ConstructorWithValuesShouldSuccess()
+        {
+            var alexaOptions = new AlexaAdapterOptions
+            {
+                TryConvertFirstActivityAttachmentToAlexaCard = true,
+                ValidateIncomingAlexaRequests = false,
+                ShouldEndSessionByDefault = false,
+                AlexaSkillId = "skill-id"
+            };
+
+            Assert.True(alexaOptions.TryConvertFirstActivityAttachmentToAlexaCard);
+            Assert.False(alexaOptions.ValidateIncomingAlexaRequests);
+            Assert.False(alexaOptions.ShouldEndSessionByDefault);
+            Assert.Equal("skill-id", alexaOptions.AlexaSkillId);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/TurnContextExTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/TurnContextExTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Moq;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests
+{
+    public class TurnContextExTests
+    {
+        [Fact]
+        public async Task OnSendActivitiesShouldSetSentActivitiesSuccessfully()
+        {
+            var adapter = new Mock<BotAdapter>();
+            var activity = new Activity { Id = "activity-id" };
+            var context = new TurnContextEx(adapter.Object, activity);
+            
+            var result = await context.SendActivityAsync(activity);
+            
+            Assert.Contains(activity, context.SentActivities);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void SentActivitiesShouldBeSetSuccessfully()
+        {
+            var adapter = new Mock<BotAdapter>();
+            var activity = new Activity { Id = "activity-id" };
+            var context = new TurnContextEx(adapter.Object, activity)
+            {
+                SentActivities = new List<Activity> { activity }
+            };
+
+            Assert.Contains(activity, context.SentActivities);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/ValidationHelperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/ValidationHelperTests.cs
@@ -6,6 +6,7 @@ using Alexa.NET.Request;
 using Bot.Builder.Community.Adapters.Alexa.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
 
@@ -16,8 +17,8 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
         [Fact]
         public async Task ValidateRequestWithEmptySignatureUrlsShouldReturnFalse()
         {
-            Microsoft.Extensions.Primitives.StringValues signatureChainUrls = string.Empty;
-            Microsoft.Extensions.Primitives.StringValues signatureHeaders = "test-signature-header";
+            StringValues signatureChainUrls = string.Empty;
+            StringValues signatureHeaders = "test-signature-header";
             var request = new Mock<HttpRequest>();
             request.SetupAllProperties();
             request.Setup(req => req.Headers.TryGetValue(AlexaAuthorizationHandler.SignatureCertChainUrlHeader, out signatureChainUrls)).Returns(true);

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/ValidationHelperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/ValidationHelperTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Alexa.NET.Request;
+using Bot.Builder.Community.Adapters.Alexa.Core;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests
+{
+    public class ValidationHelperTests
+    {
+        [Fact]
+        public async Task ValidateRequestWithEmptySignatureUrlsShouldReturnFalse()
+        {
+            Microsoft.Extensions.Primitives.StringValues signatureChainUrls = string.Empty;
+            Microsoft.Extensions.Primitives.StringValues signatureHeaders = "test-signature-header";
+            var request = new Mock<HttpRequest>();
+            request.SetupAllProperties();
+            request.Setup(req => req.Headers.TryGetValue(AlexaAuthorizationHandler.SignatureCertChainUrlHeader, out signatureChainUrls)).Returns(true);
+            request.Setup(req => req.Headers.TryGetValue(AlexaAuthorizationHandler.SignatureHeader, out signatureHeaders)).Returns(true);
+            var logger = new Mock<ILogger>();
+            logger.SetupAllProperties();
+
+            var result = await ValidationHelper.ValidateRequest(request.Object, new SkillRequest(), "", "skill-id", logger.Object);
+
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR adds unit tests for the following classes:
- [AlexaAdapterOptions](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapterOptions.cs). New code coverage 100%
- [TurnContextEx](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa/TurnContextEx.cs). New code coverage 100%
- [ValidationHelper](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa/ValidationHelper.cs). New code coverage 70%

### Specific Changes
- Added **_AlexaAdapterOptionsTests_** class with two unit tests for _AlexaAdapterOptions_.
- Added **_TurnContextExTests_** class with two unit tests for _TurnContextEx_.
- Updated _TurnContextEx_ class adding `[assembly: InternalsVisibleTo` atributte to be able to test it.
- Added **_ValidationHelperTests_** class with one unit test for _ValidationHelper_.
- Updated _ValidationHelper_ class adding `[assembly: InternalsVisibleTo` atributte to be able to test it.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/44245136/93522561-0ceaf200-f908-11ea-9dd8-fa5540dcfac0.png)
