### PR TITLE
[Alexa Adapter] Add unit tests for AlexaAuthorizationHandler class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAuthorizationHandlerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAuthorizationHandlerTests.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Alexa.NET.Request;
+using Bot.Builder.Community.Adapters.Alexa.Core;
+using Bot.Builder.Community.Adapters.Alexa.Tests.Helpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Bot.Builder.Community.Adapters.Alexa.Tests
+{
+    public class AlexaAuthorizationHandlerTests
+    {
+        private const string AlexaSkillId = "amzn1.ask.skill.b5c74146-56d3-433d-a53d-6908f606da36";
+        private const string SignatureChainUrl = "https://s3.amazonaws.com/echo.api/echo-api-cert.pem";
+        private static readonly Mock<ILogger> TestLogger = new Mock<ILogger>();
+        private static readonly SkillRequest TestSkillRequest = SkillRequestHelper.CreateIntentRequest();
+
+        [Fact]
+        public void ConstructorWithNoArgumentsShouldThrowArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AlexaAuthorizationHandler(null));
+        }
+
+        [Fact]
+        public void ConstructorWithLoggerShouldSucceed()
+        {
+            Assert.NotNull(new AlexaAuthorizationHandler(TestLogger.Object));
+        }
+
+        [Fact]
+        public void ValidateSkillIdShouldReturnTrue()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            var result = alexaAuthorizationHandler.ValidateSkillId(TestSkillRequest, AlexaSkillId);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ValidateSkillIdWithNoSkillRequestShouldReturnFalse()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            var result = alexaAuthorizationHandler.ValidateSkillId(null, "alexa-skill-id");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ValidateSkillIdWithNoAlexaSkillIdShouldReturnFalse()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            var result = alexaAuthorizationHandler.ValidateSkillId(null, null);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ValidateSkillRequestWithNoSkillRequestShouldReturnFalse()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            var result = await alexaAuthorizationHandler.ValidateSkillRequest(null, "", "", "");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ValidateSkillRequestWithNoSignatureChainUrlShouldReturnFalse()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            var result = await alexaAuthorizationHandler.ValidateSkillRequest(TestSkillRequest, "", "", "");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ValidateSkillRequestWithWrongSignatureChainUrlShouldReturnFalse()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            var result = await alexaAuthorizationHandler.ValidateSkillRequest(TestSkillRequest, "", "signature-url", "");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ValidateSkillRequestWithNoSignatureShouldReturnFalse()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            var result = await alexaAuthorizationHandler.ValidateSkillRequest(TestSkillRequest, "", SignatureChainUrl, "");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ValidateSkillRequestWithNoSkillRequestTimestampShouldReturnFalse()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            var result = await alexaAuthorizationHandler.ValidateSkillRequest(TestSkillRequest, "", SignatureChainUrl, "signature");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ValidateSkillRequestWithCertificateValidationFailedShouldReturnFalse()
+        {
+            var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
+            TestSkillRequest.Request.Timestamp = DateTime.Now;
+            var result = await alexaAuthorizationHandler.ValidateSkillRequest(TestSkillRequest, "", SignatureChainUrl, "signature");
+
+            Assert.False(result);
+        }
+    }
+}

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAuthorizationHandlerTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAuthorizationHandlerTests.cs
@@ -53,7 +53,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
         public void ValidateSkillIdWithNoAlexaSkillIdShouldReturnFalse()
         {
             var alexaAuthorizationHandler = new AlexaAuthorizationHandler(TestLogger.Object);
-            var result = alexaAuthorizationHandler.ValidateSkillId(null, null);
+            var result = alexaAuthorizationHandler.ValidateSkillId(TestSkillRequest, null);
 
             Assert.False(result);
         }


### PR DESCRIPTION
## Description
This PR adds tests for the [AlexaAuthorizationHandler](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaAuthorizationHandler.cs#L11) class increasing its code coverage from **0%** to **98%**.

### Specific Changes
- Added the AlexaAuthorizationHandlerTests file with new **xUnit** tests.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93616890-b20ad680-f9ab-11ea-8430-8f1367f6b8bf.png)
![image](https://user-images.githubusercontent.com/62260472/93616895-b3d49a00-f9ab-11ea-9378-ab881c593303.png)