### PR TITLE
[Alexa Adapter] Add unit tests for AlexaRequestMapper class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
@@ -75,12 +75,12 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             // arrange
             var skillRequest = new SkillRequest
             {
-                Request = new IntentRequest()
+                Request = new IntentRequest
                 {
                     Locale = "en-US",
-                    Intent = new Intent()
+                    Intent = new Intent
                     {
-                        Slots = new Dictionary<string, Slot>()
+                        Slots = new Dictionary<string, Slot>
                         {
                             { "phrase", new Slot() }
                         }
@@ -88,9 +88,9 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
                 },
                 Context = new Context
                 {
-                    System = new AlexaSystem() { Application = new Application(), User = new User() }
+                    System = new AlexaSystem { Application = new Application(), User = new User() }
                 },
-                Session = new Session()
+                Session = new Session
                 {
                     User = new User()
                 }
@@ -111,12 +111,12 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             // arrange
             var skillRequest = new SkillRequest
             {
-                Request = new LaunchRequest() { },
+                Request = new LaunchRequest(),
                 Context = new Context
                 {
-                    System = new AlexaSystem() { Application = new Application(), User = new User() }
+                    System = new AlexaSystem { Application = new Application(), User = new User() }
                 },
-                Session = new Session()
+                Session = new Session
                 {
                     User = new User()
                 }
@@ -137,11 +137,11 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             // arrange
             var skillRequest = new SkillRequest
             {
-                Request = new IntentRequest()
+                Request = new IntentRequest
                 {
-                    Intent = new Intent()
+                    Intent = new Intent
                     {
-                        Slots = new Dictionary<string, Slot>()
+                        Slots = new Dictionary<string, Slot>
                         {
                             { "phrase", new Slot() }
                         }
@@ -149,9 +149,9 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
                 },
                 Context = new Context
                 {
-                    System = new AlexaSystem() { Application = new Application(), User = new User() }
+                    System = new AlexaSystem { Application = new Application(), User = new User() }
                 },
-                Session = new Session()
+                Session = new Session
                 {
                     User = new User()
                 }
@@ -172,12 +172,12 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             // arrange
             var skillRequest = new SkillRequest
             {
-                Request = new LaunchRequest() { Locale = "en-US" },
+                Request = new LaunchRequest { Locale = "en-US" },
                 Context = new Context
                 {
-                    System = new AlexaSystem() { Application = new Application(), User = new User() }
+                    System = new AlexaSystem { Application = new Application(), User = new User() }
                 },
-                Session = new Session()
+                Session = new Session
                 {
                     User = new User()
                 }
@@ -201,7 +201,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var alexaAdapter = new AlexaRequestMapper();
             var inputActivity = MessageFactory.Text(text, ssml);
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { inputActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { inputActivity });
 
             Assert.Equal(text, processActivityResult.MergedActivity.Text);
             Assert.Equal(ssml, processActivityResult.MergedActivity.Speak);
@@ -216,7 +216,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var alexaAdapter = new AlexaRequestMapper();
             var inputActivity = MessageFactory.Text(text, ssml);
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { inputActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { inputActivity });
 
             Assert.Equal(text, processActivityResult.MergedActivity.Text);
             // When removing the speak tag the serializer adds the missing space at the end of the xml element. This doesn't matter for rendering in Alexa so it is fine.
@@ -232,7 +232,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var alexaAdapter = new AlexaRequestMapper();
             var inputActivity = MessageFactory.Text(text, ssml);
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { inputActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { inputActivity });
 
             Assert.Equal(text, processActivityResult.MergedActivity.Text);
             // When removing the speak tag the serializer adds the missing space at the end of the xml element. This doesn't matter for rendering in Alexa so it is fine.
@@ -248,7 +248,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var alexaAdapter = new AlexaRequestMapper();
             var inputActivity = MessageFactory.Text(text, ssml);
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { inputActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { inputActivity });
 
             Assert.Equal(text, processActivityResult.MergedActivity.Text);
             Assert.Equal($"<speak>{ssml}</speak>", processActivityResult.MergedActivity.Speak);
@@ -262,7 +262,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var firstActivity = MessageFactory.Text("This is the first activity.");
             var secondActivity = MessageFactory.Text("This is the second activity");
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, secondActivity });
 
             Assert.Equal("This is the first activity. This is the second activity", processActivityResult.MergedActivity.Text);
         }
@@ -297,7 +297,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             firstActivity.Attachments.Add(new SimpleCard { Title = "Simple card title", Content = "Test content" }.ToAttachment());
             secondActivity.Attachments = null;
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, secondActivity });
 
             Assert.Equal("This is the first activity. This is the second activity", processActivityResult.MergedActivity.Text);
             Assert.NotNull(processActivityResult.MergedActivity.Attachments);
@@ -312,7 +312,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var firstActivity = MessageFactory.Text("This is the first activity.");
             var secondActivity = MessageFactory.Text("");
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, secondActivity });
 
             // We want to preserve the period here even though it is merged with empty text.
             Assert.Equal("This is the first activity.", processActivityResult.MergedActivity.Text);
@@ -325,7 +325,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var firstActivity = MessageFactory.Text("This is the first activity");
             var secondActivity = MessageFactory.Text("");
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, secondActivity });
 
             // We want to preserve the missing period here even though it is merged with empty text.
             Assert.Equal("This is the first activity", processActivityResult.MergedActivity.Text);
@@ -342,7 +342,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var secondActivity = MessageFactory.Text("This is the second activity");
             var typingActivity = Activity.CreateTypingActivity() as Activity;
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, traceActivity, secondActivity, typingActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, traceActivity, secondActivity, typingActivity });
 
             Assert.Equal("This is the first activity. This is the second activity", processActivityResult.MergedActivity.Text);
         }
@@ -358,7 +358,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var firstActivity = MessageFactory.Text("This is the first activity.", "This is<break strength=\"strong\"/>the first activity SSML");
             var secondActivity = MessageFactory.Text("This is the second activity", "<speak>This is the second activity SSML</speak>");
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, secondActivity });
 
             Assert.Equal("<speak>This is<break strength=\"strong\"/>the first activity SSML<break strength=\"strong\"/>This is the second activity SSML</speak>", processActivityResult.MergedActivity.Speak);
             Assert.Equal("This is the first activity. This is the second activity", processActivityResult.MergedActivity.Text);
@@ -376,7 +376,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var firstActivity = MessageFactory.Text("This is the first activity.", "This is<break strength=\"strong\"/>the first activity SSML");
             var secondActivity = MessageFactory.Attachment(new HeroCard("test", "test").ToAttachment()) as Activity;
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, secondActivity });
 
             Assert.Equal("<speak>This is<break strength=\"strong\"/>the first activity SSML</speak>", processActivityResult.MergedActivity.Speak);
             Assert.Equal("This is the first activity.", processActivityResult.MergedActivity.Text);
@@ -390,7 +390,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
 
             var activity = (Activity)Activity.CreateEndOfConversationActivity();
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { activity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { activity });
 
             // Empty merged activities.
             Assert.NotNull(processActivityResult);
@@ -464,14 +464,14 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
         {
             var alexaAdapter = new AlexaRequestMapper();
 
-            var activites = new List<Activity>()
+            var activities = new List<Activity>
             {
                 MessageFactory.Text("This is the first activity."),
                 (Activity)Activity.CreateEndOfConversationActivity(),
                 MessageFactory.Text("This is the second activity")
             };
 
-            var processActivityResult = alexaAdapter.MergeActivities(activites);
+            var processActivityResult = alexaAdapter.MergeActivities(activities);
 
             Assert.Equal("This is the first activity. This is the second activity", processActivityResult.MergedActivity.Text);
             Assert.True(processActivityResult.EndOfConversationFlagged);
@@ -504,7 +504,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var firstActivity = MessageFactory.Text(message.ToString(), "This is<break strength=\"strong\"/>the first activity SSML");
             var secondActivity = MessageFactory.Text("This is the second activity.", "<speak>This is the second activity SSML</speak>");
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { firstActivity, secondActivity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { firstActivity, secondActivity });
 
             Assert.Equal("This is the first activity. Heading 1. This is another paragraph. Item 1, Item 2, Item 3. Heading 2. 1. Item 1, 2. Item 2, 3. Item 3. More info visit our web site www.microsoft.com. This is the second activity.",
                 processActivityResult.MergedActivity.Text);
@@ -574,7 +574,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
         }
 
         [Fact]
-        public void AppostrophiesNotConvertedNonSsml()
+        public void ApostrophesNotConvertedNonSsml()
         {
             const string text = "It's amazing <xml />";
             var alexaAdapter = new AlexaRequestMapper();
@@ -585,14 +585,14 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var activity = Activity.CreateMessageActivity() as Activity;
             activity.Text = text;
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { activity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { activity });
 
             var skillResponse = ExecuteActivityToResponse(mapper, processActivityResult, skillRequest);
             VerifyPlainTextResponse(skillResponse, text);
         }
 
         [Fact]
-        public void AppostrophiesNotConvertedSsml()
+        public void ApostrophesNotConvertedSsml()
         {
             const string text = "It's amazing <break /> really";
             var alexaAdapter = new AlexaRequestMapper();
@@ -603,7 +603,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var activity = Activity.CreateMessageActivity() as Activity;
             activity.Speak = text;
 
-            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity>() { activity });
+            var processActivityResult = alexaAdapter.MergeActivities(new List<Activity> { activity });
 
             var skillResponse = ExecuteActivityToResponse(mapper, processActivityResult, skillRequest);
             var outputSpeech = skillResponse.Response.OutputSpeech as SsmlOutputSpeech;
@@ -647,30 +647,30 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
 
             var hintDirective = new HintDirective("hint text");
 
-            var displayDirective = new DisplayRenderTemplateDirective()
+            var displayDirective = new DisplayRenderTemplateDirective
             {
-                Template = new BodyTemplate1()
+                Template = new BodyTemplate1
                 {
-                    BackgroundImage = new TemplateImage()
+                    BackgroundImage = new TemplateImage
                     {
                         ContentDescription = "Test",
-                        Sources = new List<ImageSource>()
+                        Sources = new List<ImageSource>
                         {
-                            new ImageSource()
+                            new ImageSource
                             {
                                 Url = "https://via.placeholder.com/576.png/09f/fff",
                             }
                         }
                     },
-                    Content = new TemplateContent()
+                    Content = new TemplateContent
                     {
-                        Primary = new TemplateText() { Text = "Test", Type = "PlainText" }
+                        Primary = new TemplateText { Text = "Test", Type = "PlainText" }
                     },
                     Title = "Test title",
                 }
             };
 
-            var simpleCard = new SimpleCard()
+            var simpleCard = new SimpleCard
             {
                 Title = "This is a simple card",
                 Content = "This is the simple card content"
@@ -682,7 +682,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
 
             var skillResponse = ExecuteActivityToResponse(mapper, new MergedActivityResult { MergedActivity = activity }, skillRequest);
 
-            VerifyCardAttachmentAndDirectiveResponse(skillResponse, simpleCard, new List<IDirective>() { hintDirective, displayDirective });
+            VerifyCardAttachmentAndDirectiveResponse(skillResponse, simpleCard, new List<IDirective> { hintDirective, displayDirective });
         }
 
         [Fact]
@@ -697,9 +697,9 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
                 Text = "Card text",
                 Images = new List<Microsoft.Bot.Schema.CardImage>
                 {
-                    new Microsoft.Bot.Schema.CardImage() { Url = "https://url" }
+                    new Microsoft.Bot.Schema.CardImage { Url = "https://url" }
                 },
-                Buttons = new List<CardAction>()
+                Buttons = new List<CardAction>
                 {
                     new CardAction { Title = "Places to buy", Type=ActionTypes.ImBack, Value="Places To Buy" },
                     new CardAction
@@ -713,7 +713,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             };
 
             var activity = Activity.CreateMessageActivity() as Activity;
-            activity.Attachments.Add(new Attachment() { ContentType = HeroCard.ContentType, Content = heroCard });
+            activity.Attachments.Add(new Attachment { ContentType = HeroCard.ContentType, Content = heroCard });
 
             var skillResponse = ExecuteActivityToResponse(mapper, new MergedActivityResult { MergedActivity = activity }, skillRequest);
 
@@ -739,7 +739,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             };
 
             var activity = Activity.CreateMessageActivity() as Activity;
-            activity.Attachments.Add(new Attachment() { ContentType = HeroCard.ContentType, Content = heroCard });
+            activity.Attachments.Add(new Attachment { ContentType = HeroCard.ContentType, Content = heroCard });
 
             var skillResponse = ExecuteActivityToResponse(mapper, new MergedActivityResult { MergedActivity = activity }, skillRequest);
 
@@ -759,7 +759,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             var signinCard = new SigninCard
             {
                 Text = "sign in text",
-                Buttons = new List<CardAction>()
+                Buttons = new List<CardAction>
                 {
                     new CardAction
                     {
@@ -772,7 +772,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             };
 
             var activity = Activity.CreateMessageActivity() as Activity;
-            activity.Attachments.Add(new Attachment() { ContentType = SigninCard.ContentType, Content = signinCard });
+            activity.Attachments.Add(new Attachment { ContentType = SigninCard.ContentType, Content = signinCard });
 
             var skillResponse = ExecuteActivityToResponse(mapper, new MergedActivityResult { MergedActivity = activity }, skillRequest);
 
@@ -807,9 +807,9 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
                 Request = request,
                 Context = new Context
                 {
-                    System = new AlexaSystem() { Application = new Application(), User = new User() }
+                    System = new AlexaSystem { Application = new Application(), User = new User() }
                 },
-                Session = new Session()
+                Session = new Session
                 {
                     User = new User()
                 }

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs
@@ -407,7 +407,6 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
             {
                 Type = ActivityTypes.Message,
                 Text = "   "
-
             };
 
             var activities = new List<Activity> { null, activity };
@@ -428,7 +427,6 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
                 Type = ActivityTypes.Message,
                 Text = "</>",
                 TextFormat = TextFormatTypes.Plain
-
             };
 
             var activities = new List<Activity> { null, activity };


### PR DESCRIPTION
## Description
This PR adds tests for the [AlexaRequestMapper](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa.Core/AlexaRequestMapper.cs#L22) class increasing its code coverage from **76%** to **99%**.

### Specific Changes
- Updated the [AlexaRequestMapperTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaRequestMapperTests.cs#L25) file with new **xUnit** tests.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93776459-ed024980-fbf9-11ea-8928-3a2224ebd003.png)
![image](https://user-images.githubusercontent.com/62260472/93776455-ea9fef80-fbf9-11ea-9a5c-b5728af35435.png)