### PR TITLE
[Alexa Adapter] Add unit tests for AlexaAdapter class

### DIFF
--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterTests.cs
@@ -1,16 +1,30 @@
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Schema;
-using Moq;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Security.Authentication;
+using Alexa.NET.Request;
+using Bot.Builder.Community.Adapters.Alexa.Core;
+using Bot.Builder.Community.Adapters.Alexa.Tests.Helpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Bot.Builder.Community.Adapters.Alexa.Tests
 {
     public class AlexaTests
     {
+        private static readonly Mock<HttpRequest> TestHttpRequest = new Mock<HttpRequest>();
+        private static readonly Mock<HttpResponse> TestHttpResponse = new Mock<HttpResponse>();
+        private static readonly Mock<IBot> TestBot = new Mock<IBot>();
+        private static readonly SkillRequest TestSkillRequest = SkillRequestHelper.CreateIntentRequest();
+
         [Fact]
         public void ConstructorWithNoArgumentsShouldSucceed()
         {
@@ -30,6 +44,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
 
             var alexaAdapter = new AlexaAdapter(new Mock<AlexaAdapterOptions>().Object);
             var conversationReference = new ConversationReference();
+
             Task BotsLogic(ITurnContext turnContext, CancellationToken cancellationToken)
             {
                 callbackInvoked = true;
@@ -50,7 +65,133 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
                 return Task.CompletedTask;
             }
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => { await alexaAdapter.ContinueConversationAsync(null, BotsLogic, default); });
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                await alexaAdapter.ContinueConversationAsync(null, BotsLogic, default);
+            });
+        }
+
+        [Fact]
+        public async void ContinueConversationAsyncWithNoBotLogicShouldThrowArgumentNullException()
+        {
+            var conversationReference = new ConversationReference();
+            var alexaAdapter = new AlexaAdapter();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => alexaAdapter.ContinueConversationAsync(conversationReference, null, default));
+        }
+
+        [Fact]
+        public async void UpdateActivityAsyncShouldThrowNotImplementedException()
+        {
+            var alexaAdapter = new AlexaAdapter();
+
+            await Assert.ThrowsAsync<NotImplementedException>(() => alexaAdapter.UpdateActivityAsync(default, default, default));
+        }
+
+        [Fact]
+        public async void DeleteActivityAsyncShouldThrowNotImplementedException()
+        {
+            var alexaAdapter = new AlexaAdapter();
+
+            await Assert.ThrowsAsync<NotImplementedException>(() => alexaAdapter.DeleteActivityAsync(default, default, default));
+        }
+
+        [Fact]
+        public async void ProcessAsyncWithNoHttpRequestShouldThrowArgumentNullException()
+        {
+            var alexaAdapter = new AlexaAdapter();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => alexaAdapter.ProcessAsync(default, TestHttpResponse.Object, TestBot.Object));
+        }
+
+        [Fact]
+        public async void ProcessAsyncWithNoHttpResponseShouldThrowArgumentNullException()
+        {
+            var alexaAdapter = new AlexaAdapter();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => alexaAdapter.ProcessAsync(TestHttpRequest.Object, default, TestBot.Object));
+        }
+
+        [Fact]
+        public async void ProcessAsyncWithNoBotShouldThrowArgumentNullException()
+        {
+            var alexaAdapter = new AlexaAdapter();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => alexaAdapter.ProcessAsync(TestHttpRequest.Object, TestHttpResponse.Object, default));
+        }
+
+        [Fact]
+        public async Task ProcessAsyncWithEmptyVersionShouldThrowException()
+        {
+            StringValues signatureChainUrls = string.Empty;
+            StringValues signatureHeaders = "test-signature-header";
+
+            TestHttpRequest.SetupAllProperties();
+            TestHttpRequest.Setup(req => req.Headers.TryGetValue(AlexaAuthorizationHandler.SignatureCertChainUrlHeader, out signatureChainUrls))
+                .Returns(true);
+            TestHttpRequest.Setup(req => req.Headers.TryGetValue(AlexaAuthorizationHandler.SignatureHeader, out signatureHeaders))
+                .Returns(true);
+            TestSkillRequest.Version = "";
+            var skillRequestJson = JsonConvert.SerializeObject(TestSkillRequest);
+            TestHttpRequest.Object.Body = new MemoryStream(Encoding.UTF8.GetBytes(skillRequestJson));
+
+            var alexaAdapter = new AlexaAdapter();
+
+            await Assert.ThrowsAsync<Exception>(() => alexaAdapter.ProcessAsync(TestHttpRequest.Object, TestHttpResponse.Object, TestBot.Object));
+        }
+
+        [Fact]
+        public async Task ProcessAsyncWithValidateRequestShouldThrowAuthenticationException()
+        {
+            StringValues signatureChainUrls = string.Empty;
+            StringValues signatureHeaders = "test-signature-header";
+
+            TestHttpRequest.SetupAllProperties();
+            TestHttpRequest.Setup(req => req.Headers.TryGetValue(AlexaAuthorizationHandler.SignatureCertChainUrlHeader, out signatureChainUrls))
+                .Returns(true);
+            TestHttpRequest.Setup(req => req.Headers.TryGetValue(AlexaAuthorizationHandler.SignatureHeader, out signatureHeaders))
+                .Returns(true);
+            var skillRequestJson = JsonConvert.SerializeObject(TestSkillRequest);
+            TestHttpRequest.Object.Body = new MemoryStream(Encoding.UTF8.GetBytes(skillRequestJson));
+
+            var alexaAdapter = new AlexaAdapter();
+
+            await Assert.ThrowsAsync<AuthenticationException>(() => alexaAdapter.ProcessAsync(TestHttpRequest.Object, TestHttpResponse.Object, TestBot.Object));
+        }
+
+        [Fact]
+        public void ProcessOutgoingActivitiesShouldReturnMergedActivityResult()
+        {
+            var alexaAdapter = new AlexaAdapter();
+            var activities = new List<Activity>
+            {
+                new Activity { Id = "activity-id", Type = ActivityTypes.EndOfConversation },
+            };
+
+            var result = alexaAdapter.ProcessOutgoingActivities(activities);
+
+            Assert.NotNull(result);
+            Assert.True(result.EndOfConversationFlagged);
+        }
+
+        [Fact]
+        public void RequestToActivityShouldReturnActivity()
+        {
+            var alexaAdapter = new AlexaAdapter();
+            var result = alexaAdapter.RequestToActivity(TestSkillRequest);
+
+            Assert.NotNull(result);
+            Assert.Equal(TestSkillRequest.Request.RequestId, result.Id);
+        }
+
+        [Fact]
+        public async Task SendActivitiesAsyncShouldReturnEmptyResourceResponse()
+        {
+            var alexaAdapter = new AlexaAdapter();
+            var result = await alexaAdapter.SendActivitiesAsync(default, default, default);
+
+            Assert.NotNull(result);
+            Assert.Empty(result);
         }
     }
 }

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterTests.cs
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterTests.cs
@@ -65,10 +65,7 @@ namespace Bot.Builder.Community.Adapters.Alexa.Tests
                 return Task.CompletedTask;
             }
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
-            {
-                await alexaAdapter.ContinueConversationAsync(null, BotsLogic, default);
-            });
+            await Assert.ThrowsAsync<ArgumentNullException>(() => alexaAdapter.ContinueConversationAsync(null, BotsLogic, default));
         }
 
         [Fact]

--- a/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Bot.Builder.Community.Adapters.Alexa.Tests.csproj
+++ b/tests/Bot.Builder.Community.Adapters.Alexa.Tests/Bot.Builder.Community.Adapters.Alexa.Tests.csproj
@@ -10,8 +10,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description
This PR adds tests for the [AlexaAdapter](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/libraries/Bot.Builder.Community.Adapters.Alexa/AlexaAdapter.cs#L23) class increasing its code coverage from **23%** to **75%**.

> **Note:** This PR needs to be merged last since it removes **MSTest** from Alexa Adapter tests project.

### Specific Changes
- Updated the [AlexaAdapterTests](https://github.com/BotBuilderCommunity/botbuilder-community-dotnet/blob/develop/tests/Bot.Builder.Community.Adapters.Alexa.Tests/AlexaAdapterTests.cs#L12) file with new **xUnit** tests.

## Testing
The following images show the new tests passing and the resulting code coverage.
![image](https://user-images.githubusercontent.com/62260472/93808715-bee52f80-fc22-11ea-9846-3c768ee59548.png)
![image](https://user-images.githubusercontent.com/62260472/93808721-c0aef300-fc22-11ea-861e-057f96bcbd3c.png)